### PR TITLE
Feature asg cpuhigh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ stage
 backup/
 output/
 examples/user-config/*/zzz-local.yaml
+*.swp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Enable AutoScalingGroups metrics collection #56
 * Move aem_password_reset_version, aem_orchestrator_version, oak_run_version stack facts to stack-provisioner-hieradata config #11
 * Modify cloud-init's extra local.yaml config to be appended to base local.yaml
+* Added feature for Publish Dispatcher to scale up/down if CPU is above/under configured threshold #26
 
 ### 2.0.0
 * Add Stack Provisioner custom hiera configuration support

--- a/ansible/playbooks/apps/full-set/compute-stacks.yaml
+++ b/ansible/playbooks/apps/full-set/compute-stacks.yaml
@@ -58,7 +58,7 @@
           PublishDispatcherASGMaxSizeParameter: "{{ publish_dispatcher.max_size }}"
           PublishDispatcherASGMinSizeParameter: "{{ publish_dispatcher.min_size }}"
           PublishDispatcherASGDesiredCapacityParameter: "{{ publish_dispatcher.desired_capacity }}"
-          PublishDispatcherASGCPUScalingParameter: "{{ publish_dispatcher.cpu_scaling_threshold }}"
+          PublishDispatcherASGCPUScalingParameters: "{{ publish_dispatcher.asg_cpu_scaling_threshold }}, {{ publish_dispatcher.asg_cpu_high_period }}, {{ publish_dispatcher.asg_cpu_high_eval_period }}, {{ publish_dispatcher.asg_cpu_low_period }}, {{ publish_dispatcher.asg_cpu_low_eval_period }}"
           PublishDispatcherRootVolSizeParameter: "{{ publish_dispatcher.root_vol_size }}"
           PublishDispatcherDataVolSizeParameter: "{{ publish_dispatcher.data_vol_size }}"
 

--- a/ansible/playbooks/apps/full-set/compute-stacks.yaml
+++ b/ansible/playbooks/apps/full-set/compute-stacks.yaml
@@ -58,6 +58,7 @@
           PublishDispatcherASGMaxSizeParameter: "{{ publish_dispatcher.max_size }}"
           PublishDispatcherASGMinSizeParameter: "{{ publish_dispatcher.min_size }}"
           PublishDispatcherASGDesiredCapacityParameter: "{{ publish_dispatcher.desired_capacity }}"
+          PublishDispatcherASGCPUScalingParameter: "{{ publish_dispatcher.cpu_scaling_threshold }}"
           PublishDispatcherRootVolSizeParameter: "{{ publish_dispatcher.root_vol_size }}"
           PublishDispatcherDataVolSizeParameter: "{{ publish_dispatcher.data_vol_size }}"
 

--- a/ansible/playbooks/apps/publish-dispatcher.yaml
+++ b/ansible/playbooks/apps/publish-dispatcher.yaml
@@ -28,6 +28,7 @@
           PublishDispatcherASGMaxSizeParameter: "{{ publish_dispatcher.max_size }}"
           PublishDispatcherASGMinSizeParameter: "{{ publish_dispatcher.min_size }}"
           PublishDispatcherASGDesiredCapacityParameter: "{{ publish_dispatcher.desired_capacity }}"
+          PublishDispatcherASGCPUScalingParameter: "{{ publish_dispatcher.cpu_scaling_threshold }}"
           PublishDispatcherRootVolSizeParameter: "{{ publish_dispatcher.root_vol_size }}"
           PublishDispatcherDataVolSizeParameter: "{{ publish_dispatcher.data_vol_size }}"
           InboundFromBastionHostSecurityGroupParameter: "{{ compute.inbound_from_bastion_host_security_group }}"

--- a/ansible/playbooks/apps/publish-dispatcher.yaml
+++ b/ansible/playbooks/apps/publish-dispatcher.yaml
@@ -28,7 +28,7 @@
           PublishDispatcherASGMaxSizeParameter: "{{ publish_dispatcher.max_size }}"
           PublishDispatcherASGMinSizeParameter: "{{ publish_dispatcher.min_size }}"
           PublishDispatcherASGDesiredCapacityParameter: "{{ publish_dispatcher.desired_capacity }}"
-          PublishDispatcherASGCPUScalingParameter: "{{ publish_dispatcher.cpu_scaling_threshold }}"
+          PublishDispatcherASGCPUScalingParameters: "{{ publish_dispatcher.asg_cpu_scaling_threshold }}, {{ publish_dispatcher.asg_cpu_high_period }}, {{ publish_dispatcher.asg_cpu_high_eval_period }}, {{ publish_dispatcher.asg_cpu_low_period }}, {{ publish_dispatcher.asg_cpu_low_eval_period }}"
           PublishDispatcherRootVolSizeParameter: "{{ publish_dispatcher.root_vol_size }}"
           PublishDispatcherDataVolSizeParameter: "{{ publish_dispatcher.data_vol_size }}"
           InboundFromBastionHostSecurityGroupParameter: "{{ compute.inbound_from_bastion_host_security_group }}"

--- a/cloudformation/apps/full-set/compute-stacks.yaml
+++ b/cloudformation/apps/full-set/compute-stacks.yaml
@@ -138,9 +138,9 @@ Parameters:
     Type: String
     Description: The Publish Dispatcher Auto Scaling Group Minimum Size
 
-  PublishDispatcherASGCPUScalingParameter:
-    Type: String
-    Description: The CPU threshold that extra Publish Dispatcher instances are scaled up at
+  PublishDispatcherASGCPUScalingParameters:
+    Type: List<Number>
+    Description: The ASG CPU scalang parameters that extra Publish Dispatcher instances are scaled up/down at
 
   PublishDispatcherRootVolSizeParameter:
     Type: Number
@@ -317,7 +317,7 @@ Resources:
         PublishDispatcherASGMaxSizeParameter: !Ref PublishDispatcherASGMaxSizeParameter
         PublishDispatcherASGMinSizeParameter: !Ref PublishDispatcherASGMinSizeParameter
         PublishDispatcherASGDesiredCapacityParameter: !Ref PublishDispatcherASGDesiredCapacityParameter
-        PublishDispatcherASGCPUScalingParameter: !Ref PublishDispatcherASGCPUScalingParameter
+        PublishDispatcherASGCPUScalingParameters: !Join [",", !Ref PublishDispatcherASGCPUScalingParameters]
         PublishDispatcherRootVolSizeParameter: !Ref PublishDispatcherRootVolSizeParameter
         PublishDispatcherDataVolSizeParameter: !Ref PublishDispatcherDataVolSizeParameter
         InboundFromBastionHostSecurityGroupParameter: !Ref InboundFromBastionHostSecurityGroupParameter

--- a/cloudformation/apps/full-set/compute-stacks.yaml
+++ b/cloudformation/apps/full-set/compute-stacks.yaml
@@ -138,6 +138,10 @@ Parameters:
     Type: String
     Description: The Publish Dispatcher Auto Scaling Group Minimum Size
 
+  PublishDispatcherASGCPUScalingParameter:
+    Type: String
+    Description: The CPU threshold that extra Publish Dispatcher instances are scaled up at
+
   PublishDispatcherRootVolSizeParameter:
     Type: Number
     Description: PublishDispatcher Instances Root EBS Volume Size
@@ -313,6 +317,7 @@ Resources:
         PublishDispatcherASGMaxSizeParameter: !Ref PublishDispatcherASGMaxSizeParameter
         PublishDispatcherASGMinSizeParameter: !Ref PublishDispatcherASGMinSizeParameter
         PublishDispatcherASGDesiredCapacityParameter: !Ref PublishDispatcherASGDesiredCapacityParameter
+        PublishDispatcherASGCPUScalingParameter: !Ref PublishDispatcherASGCPUScalingParameter
         PublishDispatcherRootVolSizeParameter: !Ref PublishDispatcherRootVolSizeParameter
         PublishDispatcherDataVolSizeParameter: !Ref PublishDispatcherDataVolSizeParameter
         InboundFromBastionHostSecurityGroupParameter: !Ref InboundFromBastionHostSecurityGroupParameter

--- a/cloudformation/apps/publish-dispatcher.yaml
+++ b/cloudformation/apps/publish-dispatcher.yaml
@@ -171,7 +171,7 @@ Resources:
     Properties:
       AdjustmentType: ChangeInCapacity
       AutoScalingGroupName: !Ref PublishDispatcherAutoScalingGroup
-      Cooldown: 300
+      Cooldown: 480
       ScalingAdjustment: 1
 
   PublishDispatcherScaleDownPolicy:
@@ -179,7 +179,7 @@ Resources:
     Properties:
       AdjustmentType: ChangeInCapacity
       AutoScalingGroupName: !Ref PublishDispatcherAutoScalingGroup
-      Cooldown: 300
+      Cooldown: 480
       ScalingAdjustment: -1
 
   PublishDispatcherCPUHighAlarm:
@@ -189,8 +189,8 @@ Resources:
       MetricName: CPUUtilization
       Namespace: AWS/EC2
       Statistic: Average
-      Period: 120
-      EvaluationPeriods: 5
+      Period: 300
+      EvaluationPeriods: 2
       Threshold: !Ref PublishDispatcherASGCPUScalingParameter
       TreatMissingData: breaching
       AlarmActions:
@@ -207,10 +207,10 @@ Resources:
       MetricName: CPUUtilization
       Namespace: AWS/EC2
       Statistic: Average
-      Period: 120
-      EvaluationPeriods: 5
+      Period: 300
+      EvaluationPeriods: 2
       Threshold: !Ref PublishDispatcherASGCPUScalingParameter
-      TreatMissingData: notBreaching
+      TreatMissingData: breaching
       AlarmActions:
       - Ref: PublishDispatcherScaleDownPolicy
       Dimensions:
@@ -223,6 +223,7 @@ Resources:
     Properties:
       AvailabilityZones:
         Ref: PublishDispatcherASGAvailabilityZoneListParameter
+      Cooldown: 480
       HealthCheckGracePeriod: 1200
       HealthCheckType: ELB
       LaunchConfigurationName:

--- a/cloudformation/apps/publish-dispatcher.yaml
+++ b/cloudformation/apps/publish-dispatcher.yaml
@@ -32,6 +32,10 @@ Parameters:
     Type: AWS::EC2::Image::Id
     Description: The Publish Dispatcher Image Id
 
+  PublishDispatcherASGCPUScalingParameters:
+    Type: CommaDelimitedList
+    Description: The ASG CPU scalang parameters that extra Publish Dispatcher instances are scaled up/down at
+
   PublishDispatcherImageRootDevice:
     Type: String
     Description: The root device name for the Publish Dispatcher Image Id
@@ -60,10 +64,6 @@ Parameters:
   PublishDispatcherASGDesiredCapacityParameter:
     Type: String
     Description: The Publish Dispatcher Auto Scaling Group Desired Capacity
-
-  PublishDispatcherASGCPUScalingParameter:
-    Type: String
-    Description: The CPU threshold that extra Publish Dispatcher instances are scaled up at
 
   PublishDispatcherRootVolSizeParameter:
     Type: Number
@@ -185,13 +185,13 @@ Resources:
   PublishDispatcherCPUHighAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmDescription: "Scale up if CPU Avg > $PublishDispatcherASGCPUScalingParameter % for 10 minutes"
+      AlarmDescription: "Scale up if CPU Avg > X % for X minutes"
       MetricName: CPUUtilization
       Namespace: AWS/EC2
       Statistic: Average
-      Period: 300
-      EvaluationPeriods: 2
-      Threshold: !Ref PublishDispatcherASGCPUScalingParameter
+      Period: !Select [1, !Ref PublishDispatcherASGCPUScalingParameters]
+      EvaluationPeriods: !Select [2, !Ref PublishDispatcherASGCPUScalingParameters]
+      Threshold: !Select [0, !Ref PublishDispatcherASGCPUScalingParameters]
       TreatMissingData: breaching
       AlarmActions:
       - Ref: PublishDispatcherScaleUpPolicy
@@ -203,13 +203,13 @@ Resources:
   PublishDispatcherCPULowAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmDescription: "Scale down if CPU Avg < $PublishDispatcherASGCPUScalingParameter % for 20 minutes"
+      AlarmDescription: "Scale down if CPU Avg < X % for X minutes"
       MetricName: CPUUtilization
       Namespace: AWS/EC2
       Statistic: Average
-      Period: 300
-      EvaluationPeriods: 4
-      Threshold: !Ref PublishDispatcherASGCPUScalingParameter
+      Period: !Select [3, !Ref PublishDispatcherASGCPUScalingParameters]
+      EvaluationPeriods: !Select [4, !Ref PublishDispatcherASGCPUScalingParameters]
+      Threshold: !Select [0, !Ref PublishDispatcherASGCPUScalingParameters]
       TreatMissingData: breaching
       AlarmActions:
       - Ref: PublishDispatcherScaleDownPolicy

--- a/cloudformation/apps/publish-dispatcher.yaml
+++ b/cloudformation/apps/publish-dispatcher.yaml
@@ -61,6 +61,10 @@ Parameters:
     Type: String
     Description: The Publish Dispatcher Auto Scaling Group Desired Capacity
 
+  PublishDispatcherASGCPUScalingParameter:
+    Type: String
+    Description: The CPU threshold that extra Publish Dispatcher instances are scaled up at
+
   PublishDispatcherRootVolSizeParameter:
     Type: Number
     Description: PublishDispatcher Instances Root EBS Volume Size
@@ -161,6 +165,59 @@ Resources:
             \ aws s3 cp s3://${DataBucketNameParameter}/${ComputeStackPrefixParameter}/stack-init.sh /opt/shinesolutions/aem-aws-stack-builder/stack-init.sh\n\
             \ chmod 755 /opt/shinesolutions/aem-aws-stack-builder/stack-init.sh\n\
             \ /opt/shinesolutions/aem-aws-stack-builder/stack-init.sh ${DataBucketNameParameter} ${ComputeStackPrefixParameter} publish-dispatcher ${AemAwsStackProvisionerVersionParameter}\n"
+
+  PublishDispatcherScaleUpPolicy:
+    Type: AWS::AutoScaling::ScalingPolicy
+    Properties:
+      AdjustmentType: ChangeInCapacity
+      AutoScalingGroupName: !Ref PublishDispatcherAutoScalingGroup
+      Cooldown: 300
+      ScalingAdjustment: 1
+
+  PublishDispatcherScaleDownPolicy:
+    Type: AWS::AutoScaling::ScalingPolicy
+    Properties:
+      AdjustmentType: ChangeInCapacity
+      AutoScalingGroupName: !Ref PublishDispatcherAutoScalingGroup
+      Cooldown: 300
+      ScalingAdjustment: -1
+
+  PublishDispatcherCPUHighAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: "Scale up if CPU Avg > $PublishDispatcherASGCPUScalingParameter % for 10 minutes"
+      MetricName: CPUUtilization
+      Namespace: AWS/EC2
+      Statistic: Average
+      Period: 120
+      EvaluationPeriods: 5
+      Threshold: !Ref PublishDispatcherASGCPUScalingParameter
+      TreatMissingData: breaching
+      AlarmActions:
+      - Ref: PublishDispatcherScaleUpPolicy
+      Dimensions:
+      - Name: AutoScalingGroupName
+        Value: !Ref PublishDispatcherAutoScalingGroup
+      ComparisonOperator: GreaterThanThreshold            
+
+  PublishDispatcherCPULowAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: "Scale down if CPU Avg < $PublishDispatcherASGCPUScalingParameter % for 10 minutes"
+      MetricName: CPUUtilization
+      Namespace: AWS/EC2
+      Statistic: Average
+      Period: 120
+      EvaluationPeriods: 5
+      Threshold: !Ref PublishDispatcherASGCPUScalingParameter
+      TreatMissingData: notBreaching
+      AlarmActions:
+      - Ref: PublishDispatcherScaleDownPolicy
+      Dimensions:
+      - Name: AutoScalingGroupName
+        Value: !Ref PublishDispatcherAutoScalingGroup
+      ComparisonOperator: LessThanThreshold
+
   PublishDispatcherAutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:

--- a/cloudformation/apps/publish-dispatcher.yaml
+++ b/cloudformation/apps/publish-dispatcher.yaml
@@ -203,12 +203,12 @@ Resources:
   PublishDispatcherCPULowAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmDescription: "Scale down if CPU Avg < $PublishDispatcherASGCPUScalingParameter % for 10 minutes"
+      AlarmDescription: "Scale down if CPU Avg < $PublishDispatcherASGCPUScalingParameter % for 20 minutes"
       MetricName: CPUUtilization
       Namespace: AWS/EC2
       Statistic: Average
       Period: 300
-      EvaluationPeriods: 2
+      EvaluationPeriods: 4
       Threshold: !Ref PublishDispatcherASGCPUScalingParameter
       TreatMissingData: breaching
       AlarmActions:

--- a/examples/user-config/full-set/sandpit-apps.yaml
+++ b/examples/user-config/full-set/sandpit-apps.yaml
@@ -98,7 +98,7 @@ publish:
   instance_type: m4.xlarge
   min_size: 2
   desired_capacity: 2
-  max_size: 2
+  max_size: 4
   root_vol_size: 20
   data_vol_size: 50
   tag_name: AEM Publish

--- a/examples/user-config/full-set/sandpit-apps.yaml
+++ b/examples/user-config/full-set/sandpit-apps.yaml
@@ -90,7 +90,11 @@ publish_dispatcher:
   elb_scheme: internet-facing
   allowed_client: '*.*.*.*'
   certificate_name: aem-stack-builder
-  cpu_scaling_threshold: 49
+  asg_cpu_scaling_threshold: 49
+  asg_cpu_high_period: 300
+  asg_cpu_high_eval_period: 1
+  asg_cpu_low_period: 300
+  asg_cpu_low_eval_period: 2
 
 publish:
   stack_name: aem-publish-stack

--- a/examples/user-config/full-set/sandpit-apps.yaml
+++ b/examples/user-config/full-set/sandpit-apps.yaml
@@ -80,7 +80,7 @@ publish_dispatcher:
   instance_type: t2.micro
   min_size: 2
   desired_capacity: 2
-  max_size: 2
+  max_size: 4
   root_vol_size: 20
   data_vol_size: 50
   load_balancer:
@@ -90,6 +90,7 @@ publish_dispatcher:
   elb_scheme: internet-facing
   allowed_client: '*.*.*.*'
   certificate_name: aem-stack-builder
+  cpu_scaling_threshold: 49
 
 publish:
   stack_name: aem-publish-stack


### PR DESCRIPTION
Added auto scale feature to Publish Dispatcher.

If CPU in ASG is above configured threshold for the last 10 minutes the scale up policy will be activated and add an additional instance.

If CPU average in ASG is below configured threshold for the last 20 minutes the scale down policy will be activated and decrease the ASG for one instance. 