### PR TITLE
Message queue alarm

### DIFF
--- a/cloudformation/apps/author.yaml
+++ b/cloudformation/apps/author.yaml
@@ -52,9 +52,9 @@ Parameters:
   UseAuthorDataVolSnapshotParameter:
     Type: String
     AllowedValues: [true, false]
-    Description: Wheather to use the Author Snapshot Data Volume.
+    Description: Whether to use the Author Snapshot Data Volume.
 
-  AuthorDataVolSnapshotParamater:
+  AuthorDataVolSnapshotParameter:
     Type: String
     Description: The Author Data Volume Snapshot Id
 
@@ -115,7 +115,7 @@ Resources:
             Fn::Sub: ${ComputeStackPrefixParameter}-AlarmNotificationTopic
       AlarmDescription: Multiple Author Instances have Enterered into Service
       AlarmName:
-        Fn::Sub: ${ComputeStackPrefixParameter}-MultiAuthorInstnaceAlarm
+        Fn::Sub: ${ComputeStackPrefixParameter}-MultiAuthorInstanceAlarm
       ComparisonOperator: GreaterThanThreshold
       MetricName: HealthyHostCount
       Namespace: AWS/ELB
@@ -147,7 +147,7 @@ Resources:
           SnapshotId:
             Fn::If:
               - UseAuthorDataVolSnapshotCondition
-              - Ref: AuthorDataVolSnapshotParamater
+              - Ref: AuthorDataVolSnapshotParameter
               - Ref: AWS::NoValue
       IamInstanceProfile:
         Fn::ImportValue: !Sub ${InstanceProfileStackPrefixParameter}-AuthorInstanceProfile
@@ -200,7 +200,7 @@ Resources:
           SnapshotId:
             Fn::If:
               - UseAuthorDataVolSnapshotCondition
-              - Ref: AuthorDataVolSnapshotParamater
+              - Ref: AuthorDataVolSnapshotParameter
               - Ref: AWS::NoValue
       IamInstanceProfile:
         Fn::ImportValue: !Sub ${InstanceProfileStackPrefixParameter}-AuthorInstanceProfile

--- a/cloudformation/apps/messaging.yaml
+++ b/cloudformation/apps/messaging.yaml
@@ -68,6 +68,25 @@ Resources:
     Properties:
       DisplayName: !Sub ${ComputeStackPrefixParameter}-alarm-notification-topic
 
+  AEMASGEventQueueLengthHighAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: "Alarm if queue length avg > 10 for 2 minutes"
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
+      Statistic: Average
+      Period: 60
+      EvaluationPeriods: 2
+      Threshold: 10
+      TreatMissingData: ignore
+      ActionsEnabled: true
+      AlarmActions:
+        - Ref: ${ComputeStackPrefixParameter}-AlarmNotificationTopic
+      Dimensions:
+        - Name: QueueName
+          Value: !Ref AEMASGEventQueueNameParameter
+      ComparisonOperator: GreaterThanThreshold
+
 Outputs:
 
   AEMAutoScalingGroupEventQueue:


### PR DESCRIPTION
These two commits are applicable to separate issues. Due to Git confusion on my part I've ended up with both in one PR.

The changes to author.yaml are minor typo corrections related to issue #28 

The changes to messaging.yaml are the addition of a new CloudWatch alarm to address issue #70 