### PR TITLE
Feature jmx enable to listen on user defined port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Introduce AuthorPublishDispatcherSubnetList and AuthorDispatcherELBSubnetList to network-exports #64
 * Introduce Consolidated architecture stacks
 * Add alarm for queue size of ASG events in Full Set architecture #70
+* Add variable declaration to configure jmxremote port for Author and Publish
 
 ### 2.0.0
 * Add Stack Provisioner custom hiera configuration support

--- a/ansible/inventory/group_vars/apps.yaml
+++ b/ansible/inventory/group_vars/apps.yaml
@@ -14,11 +14,11 @@ aem:
   publish:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
     jmxremote:
-      port: 59185
+      port: 59183
   author:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
     jmxremote:
-      port: 59185
+      port: 59182
 
 instance_profiles:
   stack_name: aem-instance-profiles-stack

--- a/ansible/inventory/group_vars/apps.yaml
+++ b/ansible/inventory/group_vars/apps.yaml
@@ -13,8 +13,12 @@ aem:
   enable_deploy_on_init: false
   publish:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
+    jmxremote:
+      port: 59185
   author:
     jvm_mem_opts: "-Xss4m -Xms4096m -Xmx8192m"
+    jmxremote:
+      port: 59185
 
 instance_profiles:
   stack_name: aem-instance-profiles-stack

--- a/ansible/templates/stack-provisioner-hieradata.j2
+++ b/ansible/templates/stack-provisioner-hieradata.j2
@@ -11,6 +11,8 @@ aem_curator::config_author_primary::enable_default_passwords: {{ aem.enable_defa
 aem_curator::config_author_primary::jvm_mem_opts: {{ aem.author.jvm_mem_opts }}
 aem_curator::config_author_primary::jmxremote_port: {{ aem.author.jmxremote.port }}
 
+aem_curator::config_author_standby::jmxremote_port: {{ aem.author.jmxremote.port }}
+
 aem_curator::config_publish::aem_password_reset_version: {{ library.aem_password_reset_version }}
 aem_curator::config_publish::enable_crxde: {{ aem.enable_crxde }}
 aem_curator::config_publish::enable_default_passwords: {{ aem.enable_default_passwords }}

--- a/ansible/templates/stack-provisioner-hieradata.j2
+++ b/ansible/templates/stack-provisioner-hieradata.j2
@@ -9,10 +9,12 @@ aem_curator::config_author_primary::aem_password_reset_version: '{{ library.aem_
 aem_curator::config_author_primary::enable_crxde: {{ aem.enable_crxde }}
 aem_curator::config_author_primary::enable_default_passwords: {{ aem.enable_default_passwords }}
 aem_curator::config_author_primary::jvm_mem_opts: {{ aem.author.jvm_mem_opts }}
+aem_curator::config_author_primary::jmxremote_port: {{ aem.author.jmxremote.port }}
 
 aem_curator::config_publish::aem_password_reset_version: {{ library.aem_password_reset_version }}
 aem_curator::config_publish::enable_crxde: {{ aem.enable_crxde }}
 aem_curator::config_publish::enable_default_passwords: {{ aem.enable_default_passwords }}
 aem_curator::config_publish::jvm_mem_opts: {{ aem.publish.jvm_mem_opts }}
+aem_curator::config_publish::jmxremote_port: {{ aem.publish.jmxremote.port }}
 
 aem_curator::config_aem_tools::oak_run_version: '{{ library.oak_run_version }}'


### PR DESCRIPTION
The first step to enable jmxremote on Author and Publisher instances to listen on a user defined port. 

https://github.com/shinesolutions/aem-aws-stack-provisioner/issues/51