### PR TITLE
Added E-Mail notification for CW Alarms

### DIFF
--- a/ansible/playbooks/apps/aem/full-set/prerequisites.yaml
+++ b/ansible/playbooks/apps/aem/full-set/prerequisites.yaml
@@ -41,6 +41,7 @@
           AEMASGEventQueueNameParameter: "{{ stack_prefix }}-{{ messaging.asg_event_sqs_queue_name }}"
           AEMASGEventTopicDisplayNameParameter: "{{ stack_prefix }} - {{ messaging.asg_event_sns_topic_display_name }}"
           AEMASGEventTopicNameParameter: "{{ stack_prefix }}-{{ messaging.asg_event_sns_topic_name }}"
+          AEMCWEventNotificationEmail: "{{ messaging.alarm_notification.contact_email }}"
 
       tags:
       - create

--- a/cloudformation/apps/aem/full-set/messaging.yaml
+++ b/cloudformation/apps/aem/full-set/messaging.yaml
@@ -22,6 +22,10 @@ Parameters:
     Type: String
     Description: The AEM Stack Auto Scaling Group Event Topic Name
 
+  AEMCWEventNotificationEmail:
+    Type: String
+    Descriptiopn: The EMail adress for sending CW Alarm messages
+
 Resources:
 
   AEMAutoScalingGroupEventQueue:
@@ -67,6 +71,9 @@ Resources:
     Type: AWS::SNS::Topic
     Properties:
       DisplayName: !Sub ${MessagingStackPrefixParameter}-alarm-notification-topic
+    Subscription:
+      Endpoint: !Ref AEMCWEventNotificationEmail
+      Protocol: email
 
   # AEMASGEventQueueLengthHighAlarm:
   #   Type: AWS::CloudWatch::Alarm

--- a/cloudformation/apps/aem/full-set/prerequisites.yaml
+++ b/cloudformation/apps/aem/full-set/prerequisites.yaml
@@ -44,6 +44,10 @@ Parameters:
     Type: String
     Description: The AEM Stack Auto Scaling Group Event Topic Name
 
+  AEMCWEventNotificationEmail:
+    Type: String
+    Descriptiopn: The EMail adress for sending CW Alarm messages
+
 Resources:
 
   InstanceProfilesStack:
@@ -88,6 +92,8 @@ Resources:
           Ref: AEMASGEventTopicDisplayNameParameter
         AEMASGEventTopicNameParameter:
           Ref: AEMASGEventTopicNameParameter
+        AEMCWEventNotificationEmail:
+          Ref: AEMCWEventNotificationEmail
 
 Outputs:
 

--- a/examples/user-config/full-set/sandpit-apps.yaml
+++ b/examples/user-config/full-set/sandpit-apps.yaml
@@ -172,6 +172,10 @@ dns_records:
     record_set_name: "{{ stack_prefix }}-publish-dispatcher"
 
 messaging:
+  stack_name: aem-messaging-stack
+  asg_event_sqs_queue_name: aem-asg-event-queue
+  asg_event_sns_topic_name: aem-asg-event-topic
+  asg_event_sns_topic_display_name: AEM ASG Event Topic
   alarm_notification:
     contact_email: user@example.com
 

--- a/examples/user-config/full-set/sandpit-apps.yaml
+++ b/examples/user-config/full-set/sandpit-apps.yaml
@@ -171,6 +171,10 @@ dns_records:
   publish_dispatcher:
     record_set_name: "{{ stack_prefix }}-publish-dispatcher"
 
+messaging:
+  alarm_notification:
+    contact_email: user@example.com
+
 stack_manager:
   ssm_stack_name: aem-stack-manager-ssm
   stack_name: aem-stack-manager


### PR DESCRIPTION
Extend Cloudformation & Ansible Template of the prerequisites messaging stack to enable E-Mail notification of CW Alarms to a pre-defined e-mail address. 

Regarding Issue#83
https://github.com/shinesolutions/aem-aws-stack-builder/issues/83