### PR TITLE
Modified S3 permissions for storing SSMOutput

### DIFF
--- a/cloudformation/apps/aem-stack-manager/instance-profiles.yaml
+++ b/cloudformation/apps/aem-stack-manager/instance-profiles.yaml
@@ -42,7 +42,7 @@ Resources:
                 Action:
                   - "s3:*"
                 Resource:
-                  - !Sub "arn:aws:s3:::${DataBucketNameParameter}/SSMOutput/*"
+                  - !Sub "arn:aws:s3:::${DataBucketNameParameter}/${S3DataStackManagerPrefix}/SSMOutput/*"
       RoleName: !Sub ${InstanceProfilesStackPrefixParameter}-AEMStackManagerSSMRole
 
   AEMStackManagerLambdaServiceRole:


### PR DESCRIPTION
To enhance the logging and debugging of the SSM commands the fiels
need to be stored in a different place.

Regarding Issue https://github.com/shinesolutions/aem-stack-manager-messenger/issues/6