### PR TITLE
add outputs to the consolidated-c output

### DIFF
--- a/cloudformation/apps/aem/consolidated/main-c.yaml
+++ b/cloudformation/apps/aem/consolidated/main-c.yaml
@@ -142,6 +142,6 @@ Resources:
             \ ${AemAwsStackProvisionerVersionParameter}\n"
     Type: AWS::EC2::Instance
 Outputs:
-    AppInstanceIP:
+    AuthorPublishDispatcherInstanceIp:
         Description: Ip Address of the resulting instance.
         Value: !GetAtt AuthorPublishDispatcherInstance.PrivateIp 

--- a/cloudformation/apps/aem/consolidated/main-c.yaml
+++ b/cloudformation/apps/aem/consolidated/main-c.yaml
@@ -141,3 +141,7 @@ Resources:
             \ ${DataBucketNameParameter} ${MainStackPrefixParameter} author-publish-dispatcher\
             \ ${AemAwsStackProvisionerVersionParameter}\n"
     Type: AWS::EC2::Instance
+Outputs:
+    AppInstanceIP:
+        Description: Ip Address of the resulting instance.
+        Value: !GetAtt AuthorPublishDispatcherInstance.PrivateIp 


### PR DESCRIPTION
Simple addition to output the ip address of the consolidated instance so we can configure DNS further down the pipeline.

Please check the sanity before merging.