### PR TITLE
Update StackManager Event Promote Author standby to primary

### DIFF
--- a/cloudformation/apps/aem-stack-manager/ssm-commands/AEM-PromoteAuthor.yaml
+++ b/cloudformation/apps/aem-stack-manager/ssm-commands/AEM-PromoteAuthor.yaml
@@ -17,6 +17,6 @@ mainSteps:
     inputs:
       runCommand:
         - '. /etc/profile'
-        - /opt/shinesolutions/aem-tools/promote-author-standby-to-primary.sh
+        - /opt/shinesolutions/aws-tools/promote-author-standby-to-primary.sh
       timeoutSeconds: '{{ executionTimeout }}'
       workingDirectory: /tmp


### PR DESCRIPTION
* update StackManager Event Promote Author standby instance to primary to call AWS Tool instead of AEM Tool