### PR TITLE
Add feature to configure scheduled aem jobs

### DIFF
--- a/ansible/inventory/group_vars/apps.yaml
+++ b/ansible/inventory/group_vars/apps.yaml
@@ -223,3 +223,57 @@ snapshots_purge:
   LiveSnapshotsPurgeInput:  '"SnapshotType": "live", "Age": "1d"'
   OfflineSnapshotsPurgeInput:  '"SnapshotType": "offline", "Age": "1w"'
   OrchestrationSnapshotsPurgeInput: '"SnapshotType": "orchestration", "Age": "4h"'
+
+scheduled_jobs:
+  author_primary:
+    offline_compaction:
+      enable: true
+      weekday: 2
+      hour: 3
+      minute: 0
+    export:
+      enable: true
+      weekday: 0-7
+      hour: 2
+      minute: 0
+    live_snapshot:
+      enable: true
+      weekday: 0-7
+      hour: '*'
+      minute: 0
+
+  author_standby:
+    live_snapshot:
+      enable: true
+      weekday: 0-7
+      hour: '*'
+      minute: 0
+
+  publish:
+    offline_compaction:
+      enable: true
+      weekday: 2
+      hour: 3
+      minute: 0
+    export:
+      enable: true
+      weekday: 0-7
+      hour: 2
+      minute: 0
+    live_snapshot:
+      enable: true
+      weekday: 0-7
+      hour: '*'
+      minute: 0
+
+  aem_orchestrator:
+    offline_compaction_snapshot:
+      enable: true
+      weekday: 1
+      hour: 1
+      minute: 15
+    offline_snapshot:
+      enable: true
+      weekday: 2-7
+      hour: 1
+      minute: 15

--- a/ansible/library/stack_manager_config.py
+++ b/ansible/library/stack_manager_config.py
@@ -158,6 +158,7 @@ class config:
             "FlushDispatcherCache": "flush-dispatcher-cache",
             "TestReadinessFullset": "test-readiness-full-set",
             "TestReadinessConsolidated": "test-readiness-consolidated",
+            "ScheduleOfflineSnapshot": "schedule-offline-snapshot"
             }
 
         messenger_config_list = {

--- a/ansible/templates/stack-provisioner-hieradata.j2
+++ b/ansible/templates/stack-provisioner-hieradata.j2
@@ -2,45 +2,45 @@ author_publish_dispatcher::enable_deploy_on_init: {{ aem.enable_deploy_on_init }
 
 author::enable_deploy_on_init: {{ aem.enable_deploy_on_init }}
 
-author_primary::cron_offline_compaction_enable: {{ scheduled_jobs.author_primary.offline_compaction.enable }}
-author_primary::cron_offline_compaction_weekday: "{{ scheduled_jobs.author_primary.offline_compaction.weekday }}"
-author_primary::cron_offline_compaction_hour: "{{ scheduled_jobs.author_primary.offline_compaction.hour }}"
-author_primary::cron_offline_compaction_minute: "{{ scheduled_jobs.author_primary.offline_compaction.minute }}"
-author_primary::cron_export_enable: {{ scheduled_jobs.author_primary.export.enable }}
-author_primary::cron_export_hour: "{{ scheduled_jobs.author_primary.export.hour }}"
-author_primary::cron_export_minute: "{{ scheduled_jobs.author_primary.export.minute }}"
-author_primary::cron_export_weekday: "{{ scheduled_jobs.author_primary.export.weekday }}"
-author_primary::cron_live_snapshot_enable: {{ scheduled_jobs.author_primary.live_snapshot.enable }}
-author_primary::cron_live_snapshot_hour: "{{ scheduled_jobs.author_primary.live_snapshot.hour }}"
-author_primary::cron_live_snapshot_minute: "{{ scheduled_jobs.author_primary.live_snapshot.minute }}"
-author_primary::cron_live_snapshot_weekday: "{{ scheduled_jobs.author_primary.live_snapshot.weekday }}"
+author_primary::scheduled_jobs::aem::enable::offline_compaction: {{ scheduled_jobs.author_primary.offline_compaction.enable }}
+author_primary::scheduled_jobs::aem::weekday::offline_compaction: "{{ scheduled_jobs.author_primary.offline_compaction.weekday }}"
+author_primary::scheduled_jobs::aem::hour::offline_compaction: "{{ scheduled_jobs.author_primary.offline_compaction.hour }}"
+author_primary::scheduled_jobs::aem::minute::offline_compaction: "{{ scheduled_jobs.author_primary.offline_compaction.minute }}"
+author_primary::scheduled_jobs::enable::export: {{ scheduled_jobs.author_primary.export.enable }}
+author_primary::scheduled_jobs::weekday::export: "{{ scheduled_jobs.author_primary.export.weekday }}"
+author_primary::scheduled_jobs::hour::export: "{{ scheduled_jobs.author_primary.export.hour }}"
+author_primary::scheduled_jobs::minute::export: "{{ scheduled_jobs.author_primary.export.minute }}"
+author_primary::scheduled_jobs::enable::live_snapshot: {{ scheduled_jobs.author_primary.live_snapshot.enable }}
+author_primary::scheduled_jobs::weekday::live_snapshot: "{{ scheduled_jobs.author_primary.live_snapshot.weekday }}"
+author_primary::scheduled_jobs::hour::live_snapshot: "{{ scheduled_jobs.author_primary.live_snapshot.hour }}"
+author_primary::scheduled_jobs::minute::live_snapshot: "{{ scheduled_jobs.author_primary.live_snapshot.minute }}"
 
-publish::cron_offline_compaction_enable: {{ scheduled_jobs.publish.offline_compaction.enable }}
-publish::cron_offline_compaction_weekday: "{{ scheduled_jobs.publish.offline_compaction.weekday }}"
-publish::cron_offline_compaction_hour: "{{ scheduled_jobs.publish.offline_compaction.hour }}"
-publish::cron_offline_compaction_minute: "{{ scheduled_jobs.publish.offline_compaction.minute }}"
-publish::cron_export_enable: {{ scheduled_jobs.publish.export.enable }}
-publish::cron_export_hour: "{{ scheduled_jobs.publish.export.hour }}"
-publish::cron_export_minute: "{{ scheduled_jobs.publish.export.minute }}"
-publish::cron_export_weekday: "{{ scheduled_jobs.publish.export.weekday }}"
-publish::cron_live_snapshot_enable: {{ scheduled_jobs.publish.live_snapshot.enable }}
-publish::cron_live_snapshot_hour: "{{ scheduled_jobs.publish.live_snapshot.hour }}"
-publish::cron_live_snapshot_minute: "{{ scheduled_jobs.publish.live_snapshot.minute }}"
-publish::cron_live_snapshot_weekday: "{{ scheduled_jobs.publish.live_snapshot.weekday }}"
+publish::scheduled_jobs::aem::enable::offline_compaction: {{ scheduled_jobs.publish.offline_compaction.enable }}
+publish::scheduled_jobs::aem::weekday::offline_compaction: "{{ scheduled_jobs.publish.offline_compaction.weekday }}"
+publish::scheduled_jobs::aem::hour::offline_compaction: "{{ scheduled_jobs.publish.offline_compaction.hour }}"
+publish::scheduled_jobs::aem::minute::offline_compaction: "{{ scheduled_jobs.publish.offline_compaction.minute }}"
+publish::scheduled_jobs::enable::export: {{ scheduled_jobs.publish.export.enable }}
+publish::scheduled_jobs::weekday::export: "{{ scheduled_jobs.publish.export.weekday }}"
+publish::scheduled_jobs::hour::export: "{{ scheduled_jobs.publish.export.hour }}"
+publish::scheduled_jobs::minute::export: "{{ scheduled_jobs.publish.export.minute }}"
+publish::scheduled_jobs::enable::live_snapshot: {{ scheduled_jobs.publish.live_snapshot.enable }}
+publish::scheduled_jobs::weekday::live_snapshot: "{{ scheduled_jobs.publish.live_snapshot.weekday }}"
+publish::scheduled_jobs::hour::live_snapshot: "{{ scheduled_jobs.publish.live_snapshot.hour }}"
+publish::scheduled_jobs::minute::live_snapshot: "{{ scheduled_jobs.publish.live_snapshot.minute }}"
 
-author_standby::cron_live_snapshot_enable: {{ scheduled_jobs.author_standby.live_snapshot.enable }}
-author_standby::cron_live_snapshot_hour: "{{ scheduled_jobs.author_standby.live_snapshot.hour }}"
-author_standby::cron_live_snapshot_minute: "{{ scheduled_jobs.author_standby.live_snapshot.minute }}"
-author_standby::cron_live_snapshot_weekday: "{{ scheduled_jobs.author_standby.live_snapshot.weekday }}"
+author_standby::scheduled_jobs::enable::live_snapshot: {{ scheduled_jobs.author_standby.live_snapshot.enable }}
+author_standby::scheduled_jobs::weekday::live_snapshot: "{{ scheduled_jobs.author_standby.live_snapshot.weekday }}"
+author_standby::scheduled_jobs::hour::live_snapshot: "{{ scheduled_jobs.author_standby.live_snapshot.hour }}"
+author_standby::scheduled_jobs::minute::live_snapshot: "{{ scheduled_jobs.author_standby.live_snapshot.minute }}"
 
-aem_orchestrator::cron_offline_compaction_snapshot_enable: {{ scheduled_jobs.aem_orchestrator.offline_compaction_snapshot.enable }}
-aem_orchestrator::cron_offline_compaction_snapshot_hour: "{{ scheduled_jobs.aem_orchestrator.offline_compaction_snapshot.hour }}"
-aem_orchestrator::cron_offline_compaction_snapshot_minute: "{{ scheduled_jobs.aem_orchestrator.offline_compaction_snapshot.minute }}"
-aem_orchestrator::cron_offline_compaction_snapshot_weekday: "{{ scheduled_jobs.aem_orchestrator.offline_compaction_snapshot.weekday }}"
-aem_orchestrator::cron_offline_snapshot_enable: {{ scheduled_jobs.aem_orchestrator.offline_snapshot.enable }}
-aem_orchestrator::cron_offline_snapshot_hour: "{{ scheduled_jobs.aem_orchestrator.offline_snapshot.hour }}"
-aem_orchestrator::cron_offline_snapshot_minute: "{{ scheduled_jobs.aem_orchestrator.offline_snapshot.minute }}"
-aem_orchestrator::cron_offline_snapshot_weekday: "{{ scheduled_jobs.aem_orchestrator.offline_snapshot.weekday }}"
+aem_orchestrator::scheduled_jobs::enable::offline_compaction_snapshot: {{ scheduled_jobs.aem_orchestrator.offline_compaction_snapshot.enable }}
+aem_orchestrator::scheduled_jobs::weekday::offline_compaction_snapshot: "{{ scheduled_jobs.aem_orchestrator.offline_compaction_snapshot.weekday }}"
+aem_orchestrator::scheduled_jobs::hour::offline_compaction_snapshot: "{{ scheduled_jobs.aem_orchestrator.offline_compaction_snapshot.hour }}"
+aem_orchestrator::scheduled_jobs::minute::offline_compaction_snapshot: "{{ scheduled_jobs.aem_orchestrator.offline_compaction_snapshot.minute }}"
+aem_orchestrator::scheduled_jobs::enable::offline_snapshot: {{ scheduled_jobs.aem_orchestrator.offline_snapshot.enable }}
+aem_orchestrator::scheduled_jobs::weekday::offline_snapshot: "{{ scheduled_jobs.aem_orchestrator.offline_snapshot.weekday }}"
+aem_orchestrator::scheduled_jobs::hour::offline_snapshot: "{{ scheduled_jobs.aem_orchestrator.offline_snapshot.hour }}"
+aem_orchestrator::scheduled_jobs::minute::offline_snapshot: "{{ scheduled_jobs.aem_orchestrator.offline_snapshot.minute }}"
 
 publish::enable_deploy_on_init: {{ aem.enable_deploy_on_init }}
 

--- a/ansible/templates/stack-provisioner-hieradata.j2
+++ b/ansible/templates/stack-provisioner-hieradata.j2
@@ -1,10 +1,56 @@
 author_publish_dispatcher::enable_deploy_on_init: {{ aem.enable_deploy_on_init }}
+
 author::enable_deploy_on_init: {{ aem.enable_deploy_on_init }}
+
+author_primary::cron_offline_compaction_enable: {{ scheduled_jobs.author_primary.offline_compaction.enable }}
+author_primary::cron_offline_compaction_weekday: "{{ scheduled_jobs.author_primary.offline_compaction.weekday }}"
+author_primary::cron_offline_compaction_hour: "{{ scheduled_jobs.author_primary.offline_compaction.hour }}"
+author_primary::cron_offline_compaction_minute: "{{ scheduled_jobs.author_primary.offline_compaction.minute }}"
+author_primary::cron_export_enable: {{ scheduled_jobs.author_primary.export.enable }}
+author_primary::cron_export_hour: "{{ scheduled_jobs.author_primary.export.hour }}"
+author_primary::cron_export_minute: "{{ scheduled_jobs.author_primary.export.minute }}"
+author_primary::cron_export_weekday: "{{ scheduled_jobs.author_primary.export.weekday }}"
+author_primary::cron_live_snapshot_enable: {{ scheduled_jobs.author_primary.live_snapshot.enable }}
+author_primary::cron_live_snapshot_hour: "{{ scheduled_jobs.author_primary.live_snapshot.hour }}"
+author_primary::cron_live_snapshot_minute: "{{ scheduled_jobs.author_primary.live_snapshot.minute }}"
+author_primary::cron_live_snapshot_weekday: "{{ scheduled_jobs.author_primary.live_snapshot.weekday }}"
+
+publish::cron_offline_compaction_enable: {{ scheduled_jobs.publish.offline_compaction.enable }}
+publish::cron_offline_compaction_weekday: "{{ scheduled_jobs.publish.offline_compaction.weekday }}"
+publish::cron_offline_compaction_hour: "{{ scheduled_jobs.publish.offline_compaction.hour }}"
+publish::cron_offline_compaction_minute: "{{ scheduled_jobs.publish.offline_compaction.minute }}"
+publish::cron_export_enable: {{ scheduled_jobs.publish.export.enable }}
+publish::cron_export_hour: "{{ scheduled_jobs.publish.export.hour }}"
+publish::cron_export_minute: "{{ scheduled_jobs.publish.export.minute }}"
+publish::cron_export_weekday: "{{ scheduled_jobs.publish.export.weekday }}"
+publish::cron_live_snapshot_enable: {{ scheduled_jobs.publish.live_snapshot.enable }}
+publish::cron_live_snapshot_hour: "{{ scheduled_jobs.publish.live_snapshot.hour }}"
+publish::cron_live_snapshot_minute: "{{ scheduled_jobs.publish.live_snapshot.minute }}"
+publish::cron_live_snapshot_weekday: "{{ scheduled_jobs.publish.live_snapshot.weekday }}"
+
+author_standby::cron_live_snapshot_enable: {{ scheduled_jobs.author_standby.live_snapshot.enable }}
+author_standby::cron_live_snapshot_hour: "{{ scheduled_jobs.author_standby.live_snapshot.hour }}"
+author_standby::cron_live_snapshot_minute: "{{ scheduled_jobs.author_standby.live_snapshot.minute }}"
+author_standby::cron_live_snapshot_weekday: "{{ scheduled_jobs.author_standby.live_snapshot.weekday }}"
+
+aem_orchestrator::cron_offline_compaction_snapshot_enable: {{ scheduled_jobs.aem_orchestrator.offline_compaction_snapshot.enable }}
+aem_orchestrator::cron_offline_compaction_snapshot_hour: "{{ scheduled_jobs.aem_orchestrator.offline_compaction_snapshot.hour }}"
+aem_orchestrator::cron_offline_compaction_snapshot_minute: "{{ scheduled_jobs.aem_orchestrator.offline_compaction_snapshot.minute }}"
+aem_orchestrator::cron_offline_compaction_snapshot_weekday: "{{ scheduled_jobs.aem_orchestrator.offline_compaction_snapshot.weekday }}"
+aem_orchestrator::cron_offline_snapshot_enable: {{ scheduled_jobs.aem_orchestrator.offline_snapshot.enable }}
+aem_orchestrator::cron_offline_snapshot_hour: "{{ scheduled_jobs.aem_orchestrator.offline_snapshot.hour }}"
+aem_orchestrator::cron_offline_snapshot_minute: "{{ scheduled_jobs.aem_orchestrator.offline_snapshot.minute }}"
+aem_orchestrator::cron_offline_snapshot_weekday: "{{ scheduled_jobs.aem_orchestrator.offline_snapshot.weekday }}"
+
 publish::enable_deploy_on_init: {{ aem.enable_deploy_on_init }}
+
 author_dispatcher::enable_deploy_on_init: {{ aem.enable_deploy_on_init }}
+
 publish_dispatcher::enable_deploy_on_init: {{ aem.enable_deploy_on_init }}
 publish_dispatcher::enable_content_healthcheck: {{ aem.enable_content_healthcheck }}
+
 orchestrator::aem_orchestrator_version: '{{ library.aem_orchestrator_version }}'
+
 chaos_monkey::simian_army_version: '{{ library.simian_army_version }}'
 
 common::proxy_enabled: {{ proxy.enabled }}

--- a/cloudformation/apps/aem-stack-manager/ssm-commands-cloudformation.yaml
+++ b/cloudformation/apps/aem-stack-manager/ssm-commands-cloudformation.yaml
@@ -108,6 +108,12 @@ Parameters:
     Description: >-
       The name of the file containing the FlushDispatcherCache SSM command
 
+  ScheduleOfflineSnapshotIncludeFile:
+    Type: String
+    Default: AEM-ScheduleOfflineSnapshot.yaml
+    Description: >-
+      The name of the file containing the ScheduleOfflineSnapshot SSM command.
+
   TestReadinessFullsetIncludeFile:
     Type: String
     Default: AEM-TestReadinessFullset.yaml
@@ -274,6 +280,16 @@ Resources:
           Name: 'AWS::Include'
           Parameters: !Sub '${S3BucketAndPrefix}/${FlushDispatcherCacheIncludeFile}'
 
+  ScheduleOfflineSnapshot:
+    Type: AWS::SSM::Document
+    Properties:
+      DocumentType: Command
+      Content:
+        Fn::Transform:
+          Name: 'AWS::Include'
+          Parameters:
+            Location: !Sub '${S3BucketAndPrefix}/${ScheduleOfflineSnapshotIncludeFile}'
+
   TestReadinessFullset:
     Type: AWS::SSM::Document
     Properties:
@@ -358,6 +374,10 @@ Outputs:
   FlushDispatcherCache:
     Description: Document name for FlushDispatcherCache
     Value: !Ref FlushDispatcherCache
+
+  ScheduleOfflineSnapshot:
+    Description: Documention name for Test Readiness Fullset
+    Value: !Ref ScheduleOfflineSnapshot
 
   TestReadinessFullset:
     Description: Documention name for Test Readiness Fullset

--- a/cloudformation/apps/aem-stack-manager/ssm-commands/AEM-ScheduleOfflineSnapshot.yaml
+++ b/cloudformation/apps/aem-stack-manager/ssm-commands/AEM-ScheduleOfflineSnapshot.yaml
@@ -1,0 +1,32 @@
+---
+schemaVersion: '2.0'
+description: >-
+  Setting scheduled job for offline snapshot and offline compaction snapshot
+parameters:
+  executionTimeout:
+    description: >-
+      (Optional) The time in seconds for a command to be completed before it is
+      considered to have failed. Default is 3600 (1 hour). Maximum is 28800 (8
+      hours).
+    type: String
+    allowedPattern: ([1-9][0-9]{0,3})|(1[0-9]{1,4})|(2[0-7][0-9]{1,3})|(28[0-7][0-9]{1,2})|(28800)
+    default: '14400'
+  jobName:
+      description: >-
+        (Required) Name of the scheduled job.
+        Allowed are <all | offline_snapshot | offline_compaction_snapshot>.
+      type: String
+  State:
+      description:  >-
+        (Required) State of the schedule job.
+        Allowed are <enable | disable>.
+      type: String
+mainSteps:
+  - action: aws:runShellScript
+    name: runShellScript
+    inputs:
+      runCommand:
+        - '. /etc/profile'
+        - '/opt/shinesolutions/aem-tools/schedule-offline-snapshots.sh {{ jobName }} {{ State }}'
+      timeoutSeconds: '{{ executionTimeout }}'
+      workingDirectory: /tmp

--- a/examples/user-config/full-set/sandpit-apps.yaml
+++ b/examples/user-config/full-set/sandpit-apps.yaml
@@ -210,3 +210,57 @@ stack_manager:
   LiveSnapshotsPurgeInput:  '"SnapshotType": "live", "Age": "1d"'
   OfflineSnapshotsPurgeInput:  '"SnapshotType": "offline", "Age": "1w"'
   OrchestrationSnapshotsPurgeInput: '"SnapshotType": "orchestration", "Age": "4h"'
+
+scheduled_jobs:
+  author_primary:
+    offline_compaction:
+      enable: true
+      weekday: 2
+      hour: 3
+      minute: 0
+    export:
+      enable: true
+      weekday: 0-7
+      hour: 2
+      minute: 0
+    live_snapshot:
+      enable: true
+      weekday: 0-7
+      hour: '*'
+      minute: 0
+
+  author_standby:
+    live_snapshot:
+      enable: true
+      weekday: 0-7
+      hour: '*'
+      minute: 0
+
+  publish:
+    offline_compaction:
+      enable: true
+      weekday: 2
+      hour: 3
+      minute: 0
+    export:
+      enable: true
+      weekday: 0-7
+      hour: 2
+      minute: 0
+    live_snapshot:
+      enable: true
+      weekday: 0-7
+      hour: '*'
+      minute: 0
+
+  aem_orchestrator:
+    offline_compaction_snapshot:
+      enable: true
+      weekday: 1
+      hour: 1
+      minute: 15
+    offline_snapshot:
+      enable: true
+      weekday: 2-7
+      hour: 1
+      minute: 15

--- a/scripts/stack-init.sh
+++ b/scripts/stack-init.sh
@@ -110,13 +110,13 @@ export FACTER_stack_prefix="${stack_prefix}"
 
 set +o errexit
 
-echo "Applying common Puppet manifest for all components..."
+echo "Applying pre-common Puppet manifest for all components..."
 puppet apply \
   --detailed-exitcodes \
   --logdest /var/log/puppet-stack-init.log \
   --modulepath modules \
   --hiera_config conf/hiera.yaml \
-  manifests/common.pp
+  manifests/pre-common.pp
 
 translate_puppet_exit_code "$?"
 
@@ -137,6 +137,16 @@ puppet apply \
   --modulepath modules \
   --hiera_config conf/hiera.yaml \
   "manifests/${component}.pp"
+
+translate_puppet_exit_code "$?"
+
+echo "Applying scheduled-job Puppet manifest for all components..."
+puppet apply \
+  --detailed-exitcodes \
+  --logdest /var/log/puppet-stack-init.log \
+  --modulepath modules \
+  --hiera_config conf/hiera.yaml \
+  manifests/scheduled-job.pp
 
 translate_puppet_exit_code "$?"
 


### PR DESCRIPTION
* Add Variable names to apps.yaml and example
* Add parameters to stack-provisioner-hieradata.j2 template
* Update stack-init to run pre-common & scheduled-jobs manifest