### PR TITLE
Add new oak version 1.6.6 for AEM 6.3.

### DIFF
--- a/ansible/inventory/group_vars/apps.yaml
+++ b/ansible/inventory/group_vars/apps.yaml
@@ -107,7 +107,10 @@ library:
   aem_aws_stack_provisioner_version: 2.4.17
   aem_orchestrator_version: 1.0.2
   aem_password_reset_version: 1.0.1
+  # AEM 6.2
   oak_run_version: 1.4.15
+  # AEM 6.3
+  # oak_run_version: 1.6.6
   aem_stack_manager_version: 1.2.3
   simian_army_version: 2.5.3
 

--- a/examples/user-config/consolidated/sandpit-apps.yaml
+++ b/examples/user-config/consolidated/sandpit-apps.yaml
@@ -50,7 +50,10 @@ library:
   aem_aws_stack_provisioner_version: 2.4.17
   aem_orchestrator_version:
   aem_password_reset_version: 1.0.1
+  # AEM 6.2
   oak_run_version: 1.4.15
+  # AEM 6.3
+  # oak_run_version: 1.6.6
 
 snapshots:
   author:

--- a/examples/user-config/full-set/sandpit-apps.yaml
+++ b/examples/user-config/full-set/sandpit-apps.yaml
@@ -95,7 +95,10 @@ library:
   aem_aws_stack_provisioner_version: 2.4.17
   aem_orchestrator_version: 1.0.2
   aem_password_reset_version: 1.0.1
+  # AEM 6.2
   oak_run_version: 1.4.15
+  # AEM 6.3
+  # oak_run_version: 1.6.6
   simian_army_version: 2.5.3
 
 certificate_manager:


### PR DESCRIPTION
Regarding issue https://github.com/shinesolutions/puppet-aem-curator/issues/47