### PR TITLE
locking down python library versions in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-ansible>=2.5.0
-awscli>=1.11.36
-boto>=2.46.1
-boto3>=1.4.3
-jinja2>=2.10
-ruamel.yaml>=0.13.7
+ansible=2.5.0
+awscli=1.11.36
+boto=2.46.1
+boto3=1.4.3
+jinja2=2.10
+ruamel.yaml=0.13.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-ansible=2.5.0
-awscli=1.11.36
-boto=2.46.1
-boto3=1.4.3
-jinja2=2.10
-ruamel.yaml=0.13.7
+ansible==2.5.0
+awscli==1.11.36
+boto==2.46.1
+boto3==1.4.3
+jinja2==2.10
+ruamel.yaml==0.13.7


### PR DESCRIPTION
Simple fix to an issue which appears to have arisen due to ansible 2.6 release yesterday.