### PR TITLE
locking down awscli to a specific value

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ansible==2.5.5
-awscli>=1.11.36
+awscli==1.11.36
 boto>=2.46.1
 boto3>=1.4.3
 botocore==1.8.37


### PR DESCRIPTION
A recent update in AWS CLI has broken compatability with Ansible and botocore version that we have locked down.

For a customer this needs to be locked until they have the permissions revised in their aws accounts. Allowing them to use more recent versions of AEM OpenCloud.