### PR TITLE
Extending HealthCheckGracePeriod for publish-dispatcher ASG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [Unreleased]
+
+### Changed
+- Extending HealthCheckGracePeriod for publish-dispatcher ASG to 30 minutes
+
 ## [3.6.1] - 2019-03-06
 
 ### Fixed

--- a/templates/cloudformation/apps/aem/full-set/publish-dispatcher.yaml
+++ b/templates/cloudformation/apps/aem/full-set/publish-dispatcher.yaml
@@ -103,7 +103,7 @@ Resources:
       Cooldown: 480
       DesiredCapacity:
         Ref: PublishDispatcherASGDesiredCapacityParameter
-      HealthCheckGracePeriod: 1200
+      HealthCheckGracePeriod: 1800
       HealthCheckType: ELB
       LaunchConfigurationName:
         Ref: PublishDispatcherLaunchConfiguration


### PR DESCRIPTION
Extending HealthCheckGracePeriod for publish-dispatcher ASG to 30 minutes