### PR TITLE
Updated cloudwatch Dashboard for full set

### DIFF
--- a/templates/cloudformation/apps/aem/full-set/author.yaml
+++ b/templates/cloudformation/apps/aem/full-set/author.yaml
@@ -8,6 +8,9 @@ Description: Create the Compute resources for the AEM Author
 Outputs:
   AuthorLoadBalancer:
     Description: The Author Load Balancer
+    Export:
+      Name:
+        Fn::Sub: ${MainStackPrefixParameter}-AuthorLoadBalancer
     Value:
       Ref: AuthorLoadBalancer
   AuthorLoadBalancerDNSName:
@@ -21,14 +24,23 @@ Outputs:
       - DNSName
   AuthorPrimaryInstance:
     Description: The Author Primary Instance
+    Export:
+      Name:
+        Fn::Sub: ${MainStackPrefixParameter}-AuthorPrimaryInstance
     Value:
       Ref: AuthorPrimaryInstance
   AuthorStandbyInstance:
     Description: The Author Standby Instance
+    Export:
+      Name:
+        Fn::Sub: ${MainStackPrefixParameter}-AuthorStandbyInstance
     Value:
       Ref: AuthorStandbyInstance
   AuthorSyncDelayAlarm:
     Description: The Author Sync Delay Alarm
+    Export:
+      Name:
+        Fn::Sub: ${MainStackPrefixParameter}-AuthorSyncDelayAlarm
     Value:
       Ref: AuthorSyncDelayAlarm
 Parameters:

--- a/templates/cloudformation/apps/aem/full-set/chaos-monkey.yaml
+++ b/templates/cloudformation/apps/aem/full-set/chaos-monkey.yaml
@@ -3,6 +3,9 @@ Description: Create the Compute resources for the AEM Chaos Monkey
 Outputs:
   ChaosMonkeyAutoScalingGroup:
     Description: The Chaos Monkey Auto Scaling Group
+    Export:
+      Name:
+        Fn::Sub: ${MainStackPrefixParameter}-ChaosMonkeyAutoScalingGroup
     Value:
       Ref: ChaosMonkeyAutoScalingGroup
   ChaosMonkeyLaunchConfiguration:

--- a/templates/cloudformation/apps/aem/full-set/monitoring.yaml
+++ b/templates/cloudformation/apps/aem/full-set/monitoring.yaml
@@ -63,7 +63,7 @@ Resources:
                 ],
                 "view": "timeSeries",
                 "stacked": false,
-                "region": "ap-southeast-2",
+                "region": "${awsRegion}",
                 "title": "Memory Utilization - EC2 - Graph",
                 "period": 300,
                 "annotations": {
@@ -92,7 +92,7 @@ Resources:
                 ],
                 "view": "singleValue",
                 "stacked": false,
-                "region": "ap-southeast-2",
+                "region": "${awsRegion}",
                 "title": "Memory Utilization - EC2",
                 "period": 300
               }
@@ -111,7 +111,7 @@ Resources:
                 ],
                 "view": "singleValue",
                 "stacked": false,
-                "region": "ap-southeast-2",
+                "region": "${awsRegion}",
                 "title": "ELB HealthyHostCount Metrics",
                 "period": 300
               }
@@ -130,7 +130,7 @@ Resources:
                 ],
                 "view": "timeSeries",
                 "stacked": false,
-                "region": "ap-southeast-2",
+                "region": "${awsRegion}",
                 "title": "ELB HealthyHostCount Metrics - Graph",
                 "period": 300
               }
@@ -149,7 +149,7 @@ Resources:
                 ],
                 "view": "singleValue",
                 "stacked": false,
-                "region": "ap-southeast-2",
+                "region": "${awsRegion}",
                 "title": "ELB UnHealthyHostCount Metrics",
                 "period": 300
               }
@@ -168,7 +168,7 @@ Resources:
                 ],
                 "view": "timeSeries",
                 "stacked": false,
-                "region": "ap-southeast-2",
+                "region": "${awsRegion}",
                 "title": "ELB UnHealthyHostCount Metrics - Graph",
                 "period": 300
               }
@@ -187,7 +187,7 @@ Resources:
                 ],
                 "view": "singleValue",
                 "stacked": false,
-                "region": "ap-southeast-2",
+                "region": "${awsRegion}",
                 "title": "ELB BackendConnectionErrors Metrics",
                 "period": 300
               }
@@ -206,7 +206,7 @@ Resources:
                 ],
                 "view": "timeSeries",
                 "stacked": false,
-                "region": "ap-southeast-2",
+                "region": "${awsRegion}",
                 "title": "ELB BackendConnectionErrors Metrics - Graph",
                 "period": 300
               }
@@ -225,7 +225,7 @@ Resources:
                 ],
                 "view": "singleValue",
                 "stacked": false,
-                "region": "ap-southeast-2",
+                "region": "${awsRegion}",
                 "title": "ELB HTTPCode_Backend_4XX Metrics",
                 "period": 300
               }
@@ -244,7 +244,7 @@ Resources:
                 ],
                 "view": "timeSeries",
                 "stacked": false,
-                "region": "ap-southeast-2",
+                "region": "${awsRegion}",
                 "title": "ELB HTTPCode_Backend_4XX Metrics - Graph",
                 "period": 300
               }
@@ -263,7 +263,7 @@ Resources:
                 ],
                 "view": "singleValue",
                 "stacked": false,
-                "region": "ap-southeast-2",
+                "region": "${awsRegion}",
                 "title": "ELB HTTPCode_Backend_5XX Metrics",
                 "period": 300
               }
@@ -282,7 +282,7 @@ Resources:
                 ],
                 "view": "timeSeries",
                 "stacked": false,
-                "region": "ap-southeast-2",
+                "region": "${awsRegion}",
                 "title": "ELB HTTPCode_Backend_5XX Metrics - Graph",
                 "period": 300
               }
@@ -301,7 +301,7 @@ Resources:
                 ],
                 "view": "singleValue",
                 "stacked": false,
-                "region": "ap-southeast-2",
+                "region": "${awsRegion}",
                 "title": "ELB RequestCount Metrics",
                 "period": 300
               }
@@ -320,7 +320,7 @@ Resources:
                 ],
                 "view": "timeSeries",
                 "stacked": false,
-                "region": "ap-southeast-2",
+                "region": "${awsRegion}",
                 "title": "ELB RequestCount Metrics - Graph",
                 "period": 300
               }
@@ -343,7 +343,7 @@ Resources:
                 ],
                 "view": "timeSeries",
                 "stacked": false,
-                "region": "ap-southeast-2",
+                "region": "${awsRegion}",
                 "title": "DiskSpaceUtilization on Data Volume /mnt/ebs1"
               }
             },
@@ -365,7 +365,7 @@ Resources:
                 ],
                 "view": "timeSeries",
                 "stacked": false,
-                "region": "ap-southeast-2",
+                "region": "${awsRegion}",
                 "title": "DiskSpaceUtilization on root volume"
               }
             },
@@ -378,7 +378,7 @@ Resources:
               "properties": {
                 "view": "timeSeries",
                 "stacked": false,
-                "region": "ap-southeast-2",
+                "region": "${awsRegion}",
                 "title": "SQS AEM ASG Event queue - Available Messages",
                 "start": "-PT3H",
                 "end": "P0D",
@@ -399,7 +399,7 @@ Resources:
                 ],
                 "view": "timeSeries",
                 "stacked": false,
-                "region": "ap-southeast-2",
+                "region": "${awsRegion}",
                 "start": "-PT3H",
                 "end": "P0D",
                 "title": "GenericJMX.delay.seconds_since_last_success"
@@ -434,10 +434,14 @@ Resources:
 
 
 Outputs:
-  applicationCloudwatchDashboardURL:
+  ApplicationCloudwatchDashboardURL:
     Description: The URL of the Cloudwatch Dashboard
     Value: !Join
       - ''
-      - - 'https://ap-southeast-2.console.aws.amazon.com/cloudwatch/home?region=ap-southeast-2#dashboards:name='
+      - - 'https://'
+        - !Ref AwsRegionParameter
+        - '.console.aws.amazon.com/cloudwatch/home?region='
+        - !Ref AwsRegionParameter
+        - '#dashboards:name='
         - !Ref MainStackPrefixParameter
         - '-monitoring-dashboard'

--- a/templates/cloudformation/apps/aem/full-set/monitoring.yaml
+++ b/templates/cloudformation/apps/aem/full-set/monitoring.yaml
@@ -15,33 +15,415 @@ Resources:
     Properties:
       DashboardBody: !Sub
         - '{
-            "widgets": [
-                {
-                    "type": "metric",
-                    "x": 0,
-                    "y": 0,
-                    "width": 9,
-                    "height": 6,
-                    "properties": {
-                        "metrics": [
-                            [ "AWS/EC2", "CPUUtilization", "AutoScalingGroupName", "${authorDispatcherAutoScalingGroupName}", { "period": 900, "label": "Author Dispatcher" } ],
-                            [ "...", "${publishAutoScalingGroupName}", { "period": 900, "label": "Publish" } ],
-                            [ "...", "${publishDispatcherAutoScalingGroupName}", { "period": 900, "label": "Publish Dispatcher" } ],
-                            [ "...", "${orchestratorAutoScalingGroupName}", { "period": 900, "label": "Orchestrator" } ]
-                        ],
-                        "view": "timeSeries",
-                        "stacked": false,
-                        "region": "${awsRegion}",
-                        "title": "CPU Utilization - EC2"
-                    }
+          "widgets": [
+            {
+              "type": "metric",
+              "x": 0,
+              "y": 0,
+              "width": 24,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "AWS/EC2", "CPUUtilization", "AutoScalingGroupName", "${authorDispatcherAutoScalingGroupName}", { "period": 300, "label": "Author Dispatcher", "stat": "Maximum" } ],
+                  [ "...", "${publishAutoScalingGroupName}", { "period": 300, "label": "Publish", "stat": "Maximum" } ],
+                  [ "...", "${publishDispatcherAutoScalingGroupName}", { "period": 300, "label": "Publish Dispatcher", "stat": "Maximum" } ],
+                  [ "...", "${orchestratorAutoScalingGroupName}", { "period": 300, "label": "Orchestrator", "stat": "Maximum" } ],
+                  [ "...", "${choasMonkeyAutoScalingGroupName}", { "period": 300, "label": "ChaosMonkey", "stat": "Maximum" } ],
+                  [ "...", "InstanceId", "${authorPrimaryInstance}", { "period": 300, "label": "AuthorPrimary", "stat": "Maximum" } ],
+                  [ "...", "${authorStandbyInstance}", { "period": 300, "label": "AuthorStandBy", "stat": "Maximum" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "${awsRegion}",
+                "title": "CPU Utilization - EC2",
+                "period": 300,
+                "annotations": {
+                  "horizontal": [
+                    { "color": "#ff7f0e", "label": "Warning", "value": 75 },
+                    { "color": "#d62728", "label": "Critical", "value": 90 }
+                  ]
                 }
-            ]
+              }
+            },
+            {
+              "type": "metric",
+              "x": 12,
+              "y": 6,
+              "width": 12,
+              "height": 9,
+              "properties": {
+                "metrics": [
+                  [ "System/Linux", "MemoryUtilization", "InstanceId", "${authorPrimaryInstance}", { "period": 300, "label": "Author Dispatcher", "stat": "Maximum" } ],
+                  [ "...", "${authorStandbyInstance}", { "period": 300, "label": "Author Dispatcher", "stat": "Maximum" } ],
+                  [ "System/Linux", "MemoryUtilization", "AutoScalingGroupName", "${authorDispatcherAutoScalingGroupName}", { "period": 300, "label": "Author Dispatcher", "stat": "Maximum" } ],
+                  [ "...", "${publishAutoScalingGroupName}", { "period": 300, "label": "Publish", "stat": "Maximum" } ],
+                  [ "...", "${publishDispatcherAutoScalingGroupName}", { "period": 300, "label": "Publish Dispatcher", "stat": "Maximum" } ],
+                  [ "...", "${choasMonkeyAutoScalingGroupName}", { "period": 300, "label": "Choas Monkey", "stat": "Maximum" } ],
+                  [ "...", "${orchestratorAutoScalingGroupName}", { "period": 300, "label": "Orchestrator", "stat": "Maximum" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "ap-southeast-2",
+                "title": "Memory Utilization - EC2 - Graph",
+                "period": 300,
+                "annotations": {
+                  "horizontal": [
+                    { "color": "#ff7f0e", "label": "Warning", "value": 75 },
+                    { "color": "#d62728", "label": "Critical", "value": 90 }
+                  ]
+                }
+              }
+            },
+            {
+              "type": "metric",
+              "x": 0,
+              "y": 6,
+              "width": 12,
+              "height": 9,
+              "properties": {
+                "metrics": [
+                  [ "System/Linux", "MemoryUtilization", "InstanceId", "${authorPrimaryInstance}", { "period": 300, "label": "Author Dispatcher", "stat": "Maximum" } ],
+                  [ "...", "${authorStandbyInstance}", { "period": 300, "label": "Author Dispatcher", "stat": "Maximum" } ],
+                  [ "System/Linux", "MemoryUtilization", "AutoScalingGroupName", "${authorDispatcherAutoScalingGroupName}", { "period": 300, "label": "Author Dispatcher", "stat": "Maximum" } ],
+                  [ "...", "${publishAutoScalingGroupName}", { "period": 300, "label": "Publish", "stat": "Maximum" } ],
+                  [ "...", "${publishDispatcherAutoScalingGroupName}", { "period": 300, "label": "Publish Dispatcher", "stat": "Maximum" } ],
+                  [ "...", "${choasMonkeyAutoScalingGroupName}", { "period": 300, "label": "Choas Monkey", "stat": "Maximum" } ],
+                  [ "...", "${orchestratorAutoScalingGroupName}", { "period": 300, "label": "Orchestrator", "stat": "Maximum" } ]
+                ],
+                "view": "singleValue",
+                "stacked": false,
+                "region": "ap-southeast-2",
+                "title": "Memory Utilization - EC2",
+                "period": 300
+              }
+            },
+            {
+              "type": "metric",
+              "x": 0,
+              "y": 15,
+              "width": 12,
+              "height": 3,
+              "properties": {
+                "metrics": [
+                  [ "AWS/ELB", "HealthyHostCount", "LoadBalancerName", "${authorELB}" ],
+                  [ "AWS/ELB", "HealthyHostCount", "LoadBalancerName", "${authorDispatcherELB}" ],
+                  [ "AWS/ELB", "HealthyHostCount", "LoadBalancerName", "${publishDispatcherELB}" ]
+                ],
+                "view": "singleValue",
+                "stacked": false,
+                "region": "ap-southeast-2",
+                "title": "ELB HealthyHostCount Metrics",
+                "period": 300
+              }
+            },
+            {
+              "type": "metric",
+              "x": 12,
+              "y": 15,
+              "width": 12,
+              "height": 3,
+              "properties": {
+                "metrics": [
+                  [ "AWS/ELB", "HealthyHostCount", "LoadBalancerName", "${authorELB}" ],
+                  [ "AWS/ELB", "HealthyHostCount", "LoadBalancerName", "${authorDispatcherELB}" ],
+                  [ "AWS/ELB", "HealthyHostCount", "LoadBalancerName", "${publishDispatcherELB}" ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "ap-southeast-2",
+                "title": "ELB HealthyHostCount Metrics - Graph",
+                "period": 300
+              }
+            },
+            {
+              "type": "metric",
+              "x": 0,
+              "y": 18,
+              "width": 12,
+              "height": 3,
+              "properties": {
+                "metrics": [
+                  [ "AWS/ELB", "UnHealthyHostCount", "LoadBalancerName", "${authorELB}" ],
+                  [ "AWS/ELB", "UnHealthyHostCount", "LoadBalancerName", "${authorDispatcherELB}" ],
+                  [ "AWS/ELB", "UnHealthyHostCount", "LoadBalancerName", "${publishDispatcherELB}" ]
+                ],
+                "view": "singleValue",
+                "stacked": false,
+                "region": "ap-southeast-2",
+                "title": "ELB UnHealthyHostCount Metrics",
+                "period": 300
+              }
+            },
+            {
+              "type": "metric",
+              "x": 12,
+              "y": 18,
+              "width": 12,
+              "height": 3,
+              "properties": {
+                "metrics": [
+                  [ "AWS/ELB", "UnHealthyHostCount", "LoadBalancerName", "${authorELB}" ],
+                  [ "AWS/ELB", "UnHealthyHostCount", "LoadBalancerName", "${authorDispatcherELB}" ],
+                  [ "AWS/ELB", "UnHealthyHostCount", "LoadBalancerName", "${publishDispatcherELB}" ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "ap-southeast-2",
+                "title": "ELB UnHealthyHostCount Metrics - Graph",
+                "period": 300
+              }
+            },
+            {
+              "type": "metric",
+              "x": 0,
+              "y": 21,
+              "width": 12,
+              "height": 3,
+              "properties": {
+                "metrics": [
+                  [ "AWS/ELB", "BackendConnectionErrors", "LoadBalancerName", "${authorELB}" ],
+                  [ "AWS/ELB", "BackendConnectionErrors", "LoadBalancerName", "${authorDispatcherELB}" ],
+                  [ "AWS/ELB", "BackendConnectionErrors", "LoadBalancerName", "${publishDispatcherELB}" ]
+                ],
+                "view": "singleValue",
+                "stacked": false,
+                "region": "ap-southeast-2",
+                "title": "ELB BackendConnectionErrors Metrics",
+                "period": 300
+              }
+            },
+            {
+              "type": "metric",
+              "x": 12,
+              "y": 21,
+              "width": 12,
+              "height": 3,
+              "properties": {
+                "metrics": [
+                  [ "AWS/ELB", "BackendConnectionErrors", "LoadBalancerName", "${authorELB}" ],
+                  [ "AWS/ELB", "BackendConnectionErrors", "LoadBalancerName", "${authorDispatcherELB}" ],
+                  [ "AWS/ELB", "BackendConnectionErrors", "LoadBalancerName", "${publishDispatcherELB}" ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "ap-southeast-2",
+                "title": "ELB BackendConnectionErrors Metrics - Graph",
+                "period": 300
+              }
+            },
+            {
+              "type": "metric",
+              "x": 0,
+              "y": 24,
+              "width": 12,
+              "height": 3,
+              "properties": {
+                "metrics": [
+                  [ "AWS/ELB", "HTTPCode_Backend_4XX", "LoadBalancerName", "${authorELB}" ],
+                  [ "AWS/ELB", "HTTPCode_Backend_4XX", "LoadBalancerName", "${authorDispatcherELB}" ],
+                  [ "AWS/ELB", "HTTPCode_Backend_4XX", "LoadBalancerName", "${publishDispatcherELB}" ]
+                ],
+                "view": "singleValue",
+                "stacked": false,
+                "region": "ap-southeast-2",
+                "title": "ELB HTTPCode_Backend_4XX Metrics",
+                "period": 300
+              }
+            },
+            {
+              "type": "metric",
+              "x": 12,
+              "y": 24,
+              "width": 12,
+              "height": 3,
+              "properties": {
+                "metrics": [
+                  [ "AWS/ELB", "HTTPCode_Backend_4XX", "LoadBalancerName", "${authorELB}" ],
+                  [ "AWS/ELB", "HTTPCode_Backend_4XX", "LoadBalancerName", "${authorDispatcherELB}" ],
+                  [ "AWS/ELB", "HTTPCode_Backend_4XX", "LoadBalancerName", "${publishDispatcherELB}" ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "ap-southeast-2",
+                "title": "ELB HTTPCode_Backend_4XX Metrics - Graph",
+                "period": 300
+              }
+            },
+            {
+              "type": "metric",
+              "x": 0,
+              "y": 27,
+              "width": 12,
+              "height": 3,
+              "properties": {
+                "metrics": [
+                  [ "AWS/ELB", "HTTPCode_Backend_5XX", "LoadBalancerName", "${authorELB}" ],
+                  [ "AWS/ELB", "HTTPCode_Backend_5XX", "LoadBalancerName", "${authorDispatcherELB}" ],
+                  [ "AWS/ELB", "HTTPCode_Backend_5XX", "LoadBalancerName", "${publishDispatcherELB}" ]
+                ],
+                "view": "singleValue",
+                "stacked": false,
+                "region": "ap-southeast-2",
+                "title": "ELB HTTPCode_Backend_5XX Metrics",
+                "period": 300
+              }
+            },
+            {
+              "type": "metric",
+              "x": 12,
+              "y": 27,
+              "width": 12,
+              "height": 3,
+              "properties": {
+                "metrics": [
+                  [ "AWS/ELB", "HTTPCode_Backend_5XX", "LoadBalancerName", "${authorELB}" ],
+                  [ "AWS/ELB", "HTTPCode_Backend_5XX", "LoadBalancerName", "${authorDispatcherELB}" ],
+                  [ "AWS/ELB", "HTTPCode_Backend_5XX", "LoadBalancerName", "${publishDispatcherELB}" ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "ap-southeast-2",
+                "title": "ELB HTTPCode_Backend_5XX Metrics - Graph",
+                "period": 300
+              }
+            },
+            {
+              "type": "metric",
+              "x": 0,
+              "y": 30,
+              "width": 12,
+              "height": 3,
+              "properties": {
+                "metrics": [
+                  [ "AWS/ELB", "RequestCount", "LoadBalancerName", "${authorELB}" ],
+                  [ "AWS/ELB", "RequestCount", "LoadBalancerName", "${authorDispatcherELB}" ],
+                  [ "AWS/ELB", "RequestCount", "LoadBalancerName", "${publishDispatcherELB}" ]
+                ],
+                "view": "singleValue",
+                "stacked": false,
+                "region": "ap-southeast-2",
+                "title": "ELB RequestCount Metrics",
+                "period": 300
+              }
+            },
+            {
+              "type": "metric",
+              "x": 12,
+              "y": 30,
+              "width": 12,
+              "height": 3,
+              "properties": {
+                "metrics": [
+                  [ "AWS/ELB", "RequestCount", "LoadBalancerName", "${authorELB}" ],
+                  [ "AWS/ELB", "RequestCount", "LoadBalancerName", "${authorDispatcherELB}" ],
+                  [ "AWS/ELB", "RequestCount", "LoadBalancerName", "${publishDispatcherELB}" ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "ap-southeast-2",
+                "title": "ELB RequestCount Metrics - Graph",
+                "period": 300
+              }
+            },
+            {
+              "type": "metric",
+              "x": 0,
+              "y": 33,
+              "width": 12,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "System/Linux", "DiskSpaceUtilization", "MountPath", "/mnt/ebs1", "InstanceId", "${authorPrimaryInstance}", "Filesystem", "/dev/xvdb" ],
+                  [ "...", "${authorStandbyInstance}", "Filesystem", "/dev/xvdb" ],
+                  [ "System/Linux", "DiskSpaceUtilization", "MountPath", "/mnt/ebs1", "AutoScalingGroupName", "${authorDispatcherAutoScalingGroupName}", "Filesystem", "/dev/xvdb" ],
+                  [ "...", "${publishAutoScalingGroupName}", "Filesystem", "/dev/xvdb" ],
+                  [ "...", "${publishDispatcherAutoScalingGroupName}", "Filesystem", "/dev/xvdb" ],
+                  [ "...", "${orchestratorAutoScalingGroupName}", "Filesystem", "/dev/xvdb" ],
+                  [ "...", "${choasMonkeyAutoScalingGroupName}", "Filesystem", "/dev/xvdb" ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "ap-southeast-2",
+                "title": "DiskSpaceUtilization on Data Volume /mnt/ebs1"
+              }
+            },
+            {
+              "type": "metric",
+              "x": 12,
+              "y": 33,
+              "width": 12,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "System/Linux", "DiskSpaceUtilization", "MountPath", "/", "InstanceId", "${authorPrimaryInstance}", "Filesystem", "/dev/xvda2" ],
+                  [ "...", "${authorStandbyInstance}", "Filesystem", "/dev/xvda2" ],
+                  [ "System/Linux", "DiskSpaceUtilization", "MountPath", "/", "AutoScalingGroupName", "${authorDispatcherAutoScalingGroupName}", "Filesystem", "/dev/xvda2" ],
+                  [ "...", "${publishAutoScalingGroupName}", "Filesystem", "/dev/xvda2" ],
+                  [ "...", "${publishDispatcherAutoScalingGroupName}", "Filesystem", "/dev/xvda2" ],
+                  [ "...", "${orchestratorAutoScalingGroupName}", "Filesystem", "/dev/xvda2" ],
+                  [ "...", "${choasMonkeyAutoScalingGroupName}", "Filesystem", "/dev/xvda2" ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "ap-southeast-2",
+                "title": "DiskSpaceUtilization on root volume"
+              }
+            },
+            {
+              "type": "metric",
+              "x": 0,
+              "y": 39,
+              "width": 12,
+              "height": 6,
+              "properties": {
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "ap-southeast-2",
+                "title": "SQS AEM ASG Event queue - Available Messages",
+                "start": "-PT3H",
+                "end": "P0D",
+                "metrics": [
+                  [ "AWS/SQS", "ApproximateNumberOfMessagesVisible", "QueueName", "${aemAsgEventQueueName}" ]
+                ]
+              }
+            },
+            {
+              "type": "metric",
+              "x": 12,
+              "y": 39,
+              "width": 12,
+              "height": 6,
+              "properties": {
+                "metrics": [
+                  [ "collectd", "GenericJMX.delay.seconds_since_last_success", "FixedDimension", "${stackPrefix}-author-standby", "Host", "${authorStandbyInstance}", "PluginInstance", "standby-status", { "period": 60, "stat": "Maximum" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "ap-southeast-2",
+                "start": "-PT3H",
+                "end": "P0D",
+                "title": "GenericJMX.delay.seconds_since_last_success"
+              }
+            }
+          ]
         }'
         - {
           authorDispatcherAutoScalingGroupName: !Join ['', [ "Fn::ImportValue": {"Fn::Sub":'${MainStackPrefixParameter}-AuthorDispatcherAutoScalingGroup'}]],
           publishAutoScalingGroupName: !Join ['', [ "Fn::ImportValue": {"Fn::Sub":'${MainStackPrefixParameter}-PublishAutoScalingGroup'}]],
           publishDispatcherAutoScalingGroupName: !Join ['', [ "Fn::ImportValue": {"Fn::Sub":'${MainStackPrefixParameter}-PublishDispatcherAutoScalingGroup'}]],
           orchestratorAutoScalingGroupName: !Join ['', [ "Fn::ImportValue": {"Fn::Sub":'${MainStackPrefixParameter}-OrchestratorAutoScalingGroup'}]],
+#          choasMonkeyAutoScalingGroupName: !Join ['', [ "Fn::ImportValue": {"Fn::Sub":'${MainStackPrefixParameter}-ChaosMonkeyAutoScalingGroup'}]],
+          choasMonkeyAutoScalingGroupName: !Join ['', [ "Fn::ImportValue": {"Fn::Sub":'${MainStackPrefixParameter}-OrchestratorAutoScalingGroup'}]],
+          authorPrimaryInstance: !Join ['', [ "Fn::ImportValue": {"Fn::Sub":'${MainStackPrefixParameter}-AuthorPrimaryInstance'}]],
+          authorStandbyInstance: !Join ['', [ "Fn::ImportValue": {"Fn::Sub":'${MainStackPrefixParameter}-AuthorStandbyInstance'}]],
+
+          authorELB: !Join ['', [ "Fn::ImportValue": {"Fn::Sub":'${MainStackPrefixParameter}-AuthorLoadBalancer'}]],
+          authorDispatcherELB: !Join ['', [ "Fn::ImportValue": {"Fn::Sub":'${MainStackPrefixParameter}-AuthorDispatcherLoadBalancer'}]],
+          publishDispatcherELB: !Join ['', [ "Fn::ImportValue": {"Fn::Sub":'${MainStackPrefixParameter}-PublishDispatcherLoadBalancer'}]],
+
+          aemAsgEventQueueName: !Join ['', [ "Fn::ImportValue": {"Fn::Sub":'${MainStackPrefixParameter}-AEMASGEventQueueName'}]],
+
+          stackPrefix: !Ref MainStackPrefixParameter,
           awsRegion: !Ref AwsRegionParameter
         }
       DashboardName: !Sub
@@ -49,3 +431,13 @@ Resources:
         - {
             MainStackPrefixParameter: !Ref MainStackPrefixParameter
           }
+
+
+Outputs:
+  applicationCloudwatchDashboardURL:
+    Description: The URL of the Cloudwatch Dashboard
+    Value: !Join
+      - ''
+      - - 'https://ap-southeast-2.console.aws.amazon.com/cloudwatch/home?region=ap-southeast-2#dashboards:name='
+        - !Ref MainStackPrefixParameter
+        - '-monitoring-dashboard'


### PR DESCRIPTION
Updated author stack and chaos-monkey to export output variable
Cloudwatch dashboard to display CPU, Memory, Disk, SQS, ELB metrics