### PR TITLE
Add new parameters to define SSH public keys to deploy on the AEM Stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Add new parameters to define SSH public keys to deploy on the AEM Stack [#313]
 
 ## 4.9.0 - 2019-08-22
 ### Added

--- a/conf/ansible/inventory/group_vars/apps.yaml
+++ b/conf/ansible/inventory/group_vars/apps.yaml
@@ -493,3 +493,8 @@ cdn:
     minimum_protocol_version: TLSv1.1_2016
     ssl_support_method: overwrite-me
   web_acl_id_parameter: overwrite-me
+
+ssh_public_keys:
+  ec2-user:
+    public_key: overwrite-me
+    public_key_type: ssh-rsa

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,10 @@ These configurations are applicable to both network and AEM application infrastr
 | cron.http_proxy | Web proxy server for http URLs, e.g. `http://someproxy:3128`, leave empty if the cron job needs to directly connect to the Internet. | Optional | None |
 | cron.https_proxy | Web proxy server for https URLs, e.g. `http://someproxy:3128`, leave empty if the cron job needs to directly connect to the Internet. | Optional | None |
 | cron.no_proxy | A comma separated value of domain suffixes that you don't want to use with the web proxy, e.g. `localhost,127.0.0.1` | Optional | None |
+| ssh_public_keys | A dict of users SSH Public keys to deploy on the AEM OpenCloud instances | Optional | None |
+| ssh_public_keys.[user_ssh_id] | Dict key name as users ssh key identifier.  | Optional | None |
+| ssh_public_keys.[user_ssh_id].public_key | Public key of the user as String.  | Optional | None |
+| ssh_public_keys.[user_ssh_id].public_key_type | Type of the ssh key such as `ssh-rsa`.  | Optional | None |
 
 ### Network configuration properties
 

--- a/templates/ansible/stack-provisioner-hieradata.j2
+++ b/templates/ansible/stack-provisioner-hieradata.j2
@@ -207,3 +207,7 @@ common::ami::publish_device_alias: {{ ami_device[os_type].publish_data_attached_
 # Service start Post sleep configuration
 common::enable_post_start_sleep: {{ aem.enable_post_start_sleep }}
 common::post_start_sleep_seconds: {{ aem.post_start_sleep_seconds }}
+
+# ssh_public_keys Import
+common::ssh_public_keys:
+{{ ssh_public_keys | to_nice_yaml | indent(width=2, first=True) }}


### PR DESCRIPTION
Add new parameters to define SSH public keys to deploy on the AEM Stack 
[#313]

Co-Authored-By: hoomaan-kh <hoomaan.kheirabadi@shinesolutions.com>