### PR TITLE
Fix 'Unsupported proxy scheme: https. Currently ansible only supports  HTTP proxies'

### DIFF
--- a/provisioners/ansible/playbooks/fetch-library.yaml
+++ b/provisioners/ansible/playbooks/fetch-library.yaml
@@ -105,6 +105,7 @@
       get_url:
         url: "https://dl.bintray.com/netflixoss/maven/com/netflix/simianarmy/simianarmy/{{ library.simian_army_version }}/simianarmy-{{ library.simian_army_version }}.war"
         dest: "{{ artifacts_dir }}"
+        validate_certs: false
         mode: 0644
       when: library.simian_army_version is defined
 


### PR DESCRIPTION
Fix 'Unsupported proxy scheme: https. Currently ansible only supports  HTTP proxies'
Reference: https://stackoverflow.com/questions/46419260/error-in-ansible-2-3-2-unsupported-proxy-scheme-https?rq=1