### PR TITLE
Fixed syntax issue for Monitoring Cloudformation Stack template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Fixed syntax issue for Monitoring Cloudformation Stack template
+
 ## 4.16.0 - 2019-09-21
 ### Changed
 - Modify extra groups handling to allow sub property names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-- Fixed syntax issue for Monitoring Cloudformation Stack template
+- Fixed syntax issue for Monitoring Cloudformation Stack template by replacing shorthands with functions
 
 ## 4.16.0 - 2019-09-21
 ### Changed

--- a/templates/cloudformation/apps/aem/full-set/monitoring.yaml
+++ b/templates/cloudformation/apps/aem/full-set/monitoring.yaml
@@ -21,7 +21,8 @@ Resources:
   ApplicationDashboard:
     Type: AWS::CloudWatch::Dashboard
     Properties:
-      DashboardBody: !Sub
+      DashboardBody:
+        Fn::Sub:
         - '{
           "widgets": [
             {
@@ -414,40 +415,59 @@ Resources:
             }
           ]
         }'
-        - {
-          authorDispatcherAutoScalingGroupName: !Join ['', [ "Fn::ImportValue": {"Fn::Sub":'${MainStackPrefixParameter}-AuthorDispatcherAutoScalingGroup'}]],
-          publishAutoScalingGroupName: !Join ['', [ "Fn::ImportValue": {"Fn::Sub":'${MainStackPrefixParameter}-PublishAutoScalingGroup'}]],
-          publishDispatcherAutoScalingGroupName: !Join ['', [ "Fn::ImportValue": {"Fn::Sub":'${MainStackPrefixParameter}-PublishDispatcherAutoScalingGroup'}]],
-          orchestratorAutoScalingGroupName: !Join ['', [ "Fn::ImportValue": {"Fn::Sub":'${MainStackPrefixParameter}-OrchestratorAutoScalingGroup'}]],
-          chaosMonkeyAutoScalingGroupName: !Join ['', [ "Fn::ImportValue": {"Fn::Sub":'${MainStackPrefixParameter}-ChaosMonkeyAutoScalingGroup'}]],
-          authorPrimaryInstance: !Join ['', [ "Fn::ImportValue": {"Fn::Sub":'${MainStackPrefixParameter}-AuthorPrimaryInstance'}]],
-          authorStandbyInstance: !Join ['', [ "Fn::ImportValue": {"Fn::Sub":'${MainStackPrefixParameter}-AuthorStandbyInstance'}]],
-
-          authorELB: !Join ['', [ "Fn::ImportValue": {"Fn::Sub":'${MainStackPrefixParameter}-AuthorLoadBalancer'}]],
-          authorDispatcherELB: !Join ['', [ "Fn::ImportValue": {"Fn::Sub":'${MainStackPrefixParameter}-AuthorDispatcherLoadBalancer'}]],
-          publishDispatcherELB: !Join ['', [ "Fn::ImportValue": {"Fn::Sub":'${MainStackPrefixParameter}-PublishDispatcherLoadBalancer'}]],
-
-          aemAsgEventQueueName: !Join ['', [ "Fn::ImportValue": {"Fn::Sub":'${MainStackPrefixParameter}-AEMASGEventQueueName'}]],
-
-          rootVolName: !Ref 'RootDeviceParameter',
-          dataVolName: !Ref 'DataDeviceParameter',
-          stackPrefix: !Ref 'MainStackPrefixParameter',
-          awsRegion: !Ref 'AwsRegionParameter'
-        }
-      DashboardName: !Sub
-        - '${MainStackPrefixParameter}-monitoring-dashboard'
-        - {
-            MainStackPrefixParameter: !Ref 'MainStackPrefixParameter'
-          }
-
-
+        - authorDispatcherAutoScalingGroupName:
+            Fn::ImportValue:
+              Fn::Sub: "${MainStackPrefixParameter}-AuthorDispatcherAutoScalingGroup"
+          publishAutoScalingGroupName:
+            Fn::ImportValue:
+              Fn::Sub: "${MainStackPrefixParameter}-PublishAutoScalingGroup"
+          publishDispatcherAutoScalingGroupName:
+            Fn::ImportValue:
+              Fn::Sub: "${MainStackPrefixParameter}-PublishDispatcherAutoScalingGroup"
+          orchestratorAutoScalingGroupName:
+            Fn::ImportValue:
+              Fn::Sub: "${MainStackPrefixParameter}-OrchestratorAutoScalingGroup"
+          chaosMonkeyAutoScalingGroupName:
+            Fn::ImportValue:
+              Fn::Sub: "${MainStackPrefixParameter}-ChaosMonkeyAutoScalingGroup"
+          authorPrimaryInstance:
+            Fn::ImportValue:
+              Fn::Sub: "${MainStackPrefixParameter}-AuthorPrimaryInstance"
+          authorStandbyInstance:
+            Fn::ImportValue:
+              Fn::Sub: "${MainStackPrefixParameter}-AuthorStandbyInstance"
+          authorELB:
+            Fn::ImportValue:
+              Fn::Sub: "${MainStackPrefixParameter}-AuthorLoadBalancer"
+          authorDispatcherELB:
+            Fn::ImportValue:
+              Fn::Sub: "${MainStackPrefixParameter}-AuthorDispatcherLoadBalancer"
+          publishDispatcherELB:
+            Fn::ImportValue:
+              Fn::Sub: "${MainStackPrefixParameter}-PublishDispatcherLoadBalancer"
+          aemAsgEventQueueName:
+            Fn::ImportValue:
+              Fn::Sub: "${MainStackPrefixParameter}-AEMASGEventQueueName"
+          rootVolName:
+            Ref: 'RootDeviceParameter'
+          dataVolName:
+            Ref: 'DataDeviceParameter'
+          stackPrefix:
+            Ref: 'MainStackPrefixParameter'
+          awsRegion:
+            Ref: 'AwsRegionParameter'
+      DashboardName:
+        Fn::Sub:
+        - "${MainStackPrefixParameter}-monitoring-dashboard"
+        - MainStackPrefixParameter:
+            Ref: 'MainStackPrefixParameter'
 Outputs:
-
   ApplicationCloudwatchDashboardURL:
     Description: The URL of the Cloudwatch Dashboard
-    Value: !Sub
-      - 'https://${awsRegion}.console.aws.amazon.com/cloudwatch/home?region=${awsRegion}#dashboards:name=${stackPrefix}-monitoring-dashboard'
-      - {
-          awsRegion: !Ref 'AwsRegionParameter',
-          stackPrefix: !Ref 'MainStackPrefixParameter'
-        }
+    Value:
+      Fn::Sub:
+      - "https://${awsRegion}.console.aws.amazon.com/cloudwatch/home?region=${awsRegion}#dashboards:name=${stackPrefix}-monitoring-dashboard"
+      - awsRegion:
+          Ref: 'AwsRegionParameter'
+        stackPrefix:
+          Ref: 'MainStackPrefixParameter'


### PR DESCRIPTION
Fixed syntax issue for Monitoring Cloudformation Stack template.

The `make config` was making this Cloudformation template unusuable. With this PR the `make config` does not make the cloudformation template unusable and will keep all the defined parameters.