### PR TITLE
Add new permissions for AEM Stack Manager [#295]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Add new permissions for AEM Stack Manager to allow updating ASG scaling processes [#295]
+
 ### Changed
 - Rename switch-dns parameters for consistency with AOC Manager parameter names
 

--- a/templates/cloudformation/apps/aem-stack-manager/instance-profiles.yaml
+++ b/templates/cloudformation/apps/aem-stack-manager/instance-profiles.yaml
@@ -75,6 +75,8 @@ Resources:
                   - autoscaling:UpdateAutoScalingGroup
                   - autoscaling:EnterStandby
                   - autoscaling:ExitStandby
+                  - autoscaling:SuspendProcesses
+                  - autoscaling:ResumeProcesses
                 Effect: Allow
                 Resource: '*'
               - Action:


### PR DESCRIPTION
Add new permissions for AEM Stack Manager to allow updating ASG scaling 
processes [#295].

This permission update is needed to allow the `aem_offline_snapshot.py` lambda function to update the ASG suspendes processes. 

This PR is needed by PR https://github.com/shinesolutions/aem-stack-manager-cloud/pull/41