### PR TITLE
Update AEM System users configuration parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix Consolidated DNS switch incorrectly generate Author-Dispatcher target
 
+### Added
+- Added to FAQ to explain why the admin user password change can fail
+- Added to FAQ to explain why the system user configuration parameters changed #352
+- Add new configuration parameters `system_users.[author|publish].[admin|deployer|exporter|importer|orchestrator|replicator].[name|path]` #352
+- Add new hiera parameter `author::aem_system_users` & `publish::aem_system_users` #352
+
+### Changed
+- configuration parameter `system_users.[author|publish].admin.path` (previously known as `system_users.admin.path`) is now a *mandatory* parameter
+
+### Removed
+- Removed configuration parameters `system_users.[admin|deployer|exporter|importer|orchestrator|replicator]` #352
+- Removed hiera parameter `common::aem_system_users` #352
+
+
 ## 4.23.2 - 2019-10-17
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - configuration parameter `system_users.[author|publish].admin.path` (previously known as `system_users.admin.path`) is now a *mandatory* parameter
+- Update FAQ for reconfiguration with new system_users parameters #352
 
 ### Removed
 - Removed configuration parameters `system_users.[admin|deployer|exporter|importer|orchestrator|replicator]` #352

--- a/conf/ansible/inventory/group_vars/apps.yaml
+++ b/conf/ansible/inventory/group_vars/apps.yaml
@@ -174,32 +174,60 @@ reconfiguration:
 
 
 system_users:
-  admin:
-    name: admin
-    path: /home/users/d
-  authentication-service:
-    name: authentication-service
-    path: /home/users/system
-    authorizable_keystore:
-      password:
-      certificate_chain:
-      private_key:
-      private_key_alias:
-  deployer:
-    name: deployer
-    path: /home/users/q
-  exporter:
-    name: exporter
-    path: /home/users/e
-  importer:
-    name: importer
-    path: /home/users/i
-  orchestrator:
-    name: orchestrator
-    path: /home/users/o
-  replicator:
-    name: replicator
-    path: /home/users/r
+  author:
+    admin:
+      name: admin
+      path: overwrite-me
+    authentication-service:
+      name: authentication-service
+      path: /home/users/system
+      authorizable_keystore:
+        password:
+        certificate_chain:
+        private_key:
+        private_key_alias:
+    deployer:
+      name: deployer
+      path: /home/users/q
+    exporter:
+      name: exporter
+      path: /home/users/e
+    importer:
+      name: importer
+      path: /home/users/i
+    orchestrator:
+      name: orchestrator
+      path: /home/users/o
+    replicator:
+      name: replicator
+      path: /home/users/r
+  publish:
+    admin:
+      name: admin
+      path: overwrite-me
+    authentication-service:
+      name: authentication-service
+      path: /home/users/system
+      authorizable_keystore:
+        password:
+        certificate_chain:
+        private_key:
+        private_key_alias:
+    deployer:
+      name: deployer
+      path: /home/users/q
+    exporter:
+      name: exporter
+      path: /home/users/e
+    importer:
+      name: importer
+      path: /home/users/i
+    orchestrator:
+      name: orchestrator
+      path: /home/users/o
+    replicator:
+      name: replicator
+      path: /home/users/r
 
 # Parameters needed for SAML configuration
 saml:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -317,8 +317,9 @@ These configurations are applicable only when you run repository reconfiguration
 | reconfiguration.author.run_modes | A list of runmodes you want to set in `start-env` | Optional | `[]` |
 | reconfiguration.publish.run_modes | A list of runmodes you want to set in `start-env` | Optional | `[]` |
 | reconfiguration.ssl_keystore_password | [Java Keystore](https://www.digitalocean.com/community/tutorials/java-keytool-essentials-working-with-java-keystores) password used in AEM Author and Publish.  | Optional | `changeit` |
-| system_users.[admin|deployer|exporter|importer|orchestrator|replicator].name | AEM system user username. Don't overwrite this unless you want to use non-AEM OpenCloud system users. | Optional | |
-| system_users.[admin|deployer|exporter|importer|orchestrator|replicator].name | AEM system user path in the repository. Don't overwrite this unless you want to use non-AEM OpenCloud system users. | Optional | |
+| system_users.[author|publish].[admin|deployer|exporter|importer|orchestrator|replicator].name | AEM system user username for each component. Don't overwrite this unless you want to use non-AEM OpenCloud system users. | Optional | |
+| system_users.[author|publish].admin.path | AEM admin user path in the repository for each component. | mandatory | |
+| system_users.[author|publish].[deployer|exporter|importer|orchestrator|replicator].path | AEM system user path in the repository for each component. Don't overwrite this unless you want to use non-AEM OpenCloud system users. | Optional | |
 
 ### AEM SAML configuration properties:
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -165,24 +165,45 @@ To create a stack with the old FS structure you need AMIs created with Packer-AE
       run_modes: []
 
   system_users:
-    admin:
-      name: admin
-      path: /home/users/d
-    deployer:
-      name: deployer
-      path: /home/users/q
-    exporter:
-      name: exporter
-      path: /home/users/e
-    importer:
-      name: importer
-      path: /home/users/i
-    orchestrator:
-      name: orchestrator
-      path: /home/users/o
-    replicator:
-      name: replicator
-      path: /home/users/r
+    author:
+      admin:
+        name: admin
+        path: overwrite-me
+      deployer:
+        name: deployer
+        path: /home/users/q
+      exporter:
+        name: exporter
+        path: /home/users/e
+      importer:
+        name: importer
+        path: /home/users/i
+      orchestrator:
+        name: orchestrator
+        path: /home/users/o
+      replicator:
+        name: replicator
+        path: /home/users/r
+    publish:
+      admin:
+        name: admin
+        path: overwrite-me
+      deployer:
+        name: deployer
+        path: /home/users/q
+      exporter:
+        name: exporter
+        path: /home/users/e
+      importer:
+        name: importer
+        path: /home/users/i
+      orchestrator:
+        name: orchestrator
+        path: /home/users/o
+      replicator:
+        name: replicator
+        path: /home/users/r
+
   ```
 
   This configuration profile will...

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -223,3 +223,12 @@ To create a stack with the old FS structure you need AMIs created with Packer-AE
     * Migrate AEM Global Truststore (Only if migration enabled and removing disabled)
 
     This process makes sure that all configuration done with AEM OpenCloud are getting reseted and the new AEM Stack will have all it's own environment specific parameters.
+
+- **Q:** Why does the configuration parameters `system_users` are now configurable per component ? <br>
+  **A:** The configuration parameter `system_users` changed as the user path of the AEM System Users can be different on each component. E.g. the admin user is controlled by AEM [Link](https://helpx.adobe.com/experience-manager/6-3/sites/administering/using/security.html#UsersandGroupsinAEM), therefore the user path of the admin user is different on each AEM environment.
+
+
+- **Q:** Why does provisioning fail while changing the admin user password in AEM ? <br>
+  **A:** The provisioning process ```"[author|publish]: Set admin password for current stack"``` ([Link](https://github.com/shinesolutions/puppet-aem-curator/blob/master/manifests/config_aem_system_users.pp#L48)) can fail, when the user path of the `admin` user is not correct in the configuration profile([Author](https://github.com/shinesolutions/aem-aws-stack-builder/blob/master/conf/ansible/inventory/group_vars/apps.yaml#L180)|[Publish](https://github.com/shinesolutions/aem-aws-stack-builder/blob/master/conf/ansible/inventory/group_vars/apps.yaml#L207)).
+
+  To check the path you need to configure you can either look in the repository at `/home/users` or search for the `admin` user in [useradmin](http://localhost:4502/useradmin).

--- a/docs/upgrade-guide.md
+++ b/docs/upgrade-guide.md
@@ -6,6 +6,9 @@ This upgrade guide covers the changes required when you already use AEM AWS Stac
 
 * rhel7 default data volumes are now `/dev/xvdb` and `/dev/xvdc`, if you used to rely on the previous defaults of `/dev/sdb` and `/dev/sdc`, then you have to explicitly define those configurations
 
+### To 4.24.0
+- Rename `system_users.[admin|deployer|exporter|importer|orchestrator|replicator][.name|path]` configuration property to `system_users.[author|publish].[admin|deployer|exporter|importer|orchestrator|replicator].[name|path]`
+
 ### To 3.7.0
 
 **Update configuration properties for configuring Publish-Dispatcher AutoScalingGroup:**

--- a/templates/ansible/stack-provisioner-hieradata.j2
+++ b/templates/ansible/stack-provisioner-hieradata.j2
@@ -158,8 +158,12 @@ common::enable_truststore_removal: {{ reconfiguration.enable_truststore_removal 
 common::certificate_arn: {{ reconfiguration.certificate_arn }}
 common::certificate_key_arn: {{ reconfiguration.certificate_key_arn }}
 common::aem_ssl_keystore_password: {{ reconfiguration.ssl_keystore_password }}
-common::aem_system_users:
-{{ system_users | to_nice_yaml | indent(width=2, first=True) }}
+
+# define AEM System Users
+author::aem_system_users:
+{{ system_users.author | to_nice_yaml | indent(width=2, first=True) }}
+publish::aem_system_users:
+{{ system_users.publish | to_nice_yaml | indent(width=2, first=True) }}
 
 # Logrotation configuration. For configuration parameters see https://github.com/voxpupuli/puppet-logrotate
 common::logrotation::config:


### PR DESCRIPTION
Update configura

 ### Added
- Added to FAQ to explain why the admin user password change can fail
- Added to FAQ to explain why the system user configuration parameters changed #352
- Add new configuration parameters `system_users.[author|publish].[admin|deployer|exporter|importer|orchestrator|replicator].[name|path]` #352
- Add new hiera parameter `author::aem_system_users` & `publish::aem_system_users` #352

### Changed
- configuration parameter `system_users.[author|publish].admin.path` (previously known as `system_users.admin.path`) is now a *mandatory* parameter

### Removed
- Removed configuration parameters `system_users.[admin|deployer|exporter|importer|orchestrator|replicator]` #352
- Removed hiera parameter `common::aem_system_users` #352

