### PR TITLE
Extend timeout for snapshot purge lambda function from 5 mins to 15 mins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+-  Extend timeout for snapshot purge lambda function from 5 mins to 15 mins
+
 ### Fixed
 - Fix Consolidated DNS switch incorrectly generate Author-Dispatcher target
 

--- a/templates/cloudformation/apps/aem-stack-manager/utilities.yaml
+++ b/templates/cloudformation/apps/aem-stack-manager/utilities.yaml
@@ -251,5 +251,5 @@ Resources:
         Fn::ImportValue:
           Fn::Sub: ${MainStackPrefixParameter}-StackManagerLambdaServiceRoleArn
       Runtime: python2.7
-      Timeout: 300
+      Timeout: 900
     Type: AWS::Lambda::Function


### PR DESCRIPTION
Extend timeout for snapshot purge lambda function from 5 mins to 15 mins