### PR TITLE
feat(#366): add feature to remove all available Cloudwatch Loggroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Add feature to enable removal of all available Cloudwatch Loggroups while deleting an AEM Stack [#366]
+
 ## 4.25.0 - 2019-12-17
 ### Changed
 - Upgrade AEM AWS Stack Provisioner to 4.26.0

--- a/conf/ansible/inventory/group_vars/all.yaml
+++ b/conf/ansible/inventory/group_vars/all.yaml
@@ -8,6 +8,7 @@ aws:
   cloudwatch:
     enable_log_subscription: false
     log_subscription_arn: overwrite-me
+    enable_cloudwatch_cleanup: false
 
 proxy:
   enabled: false

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,7 @@ These configurations are applicable to both network and AEM application infrastr
 | aws.availability_zone_list | Comma separated list of [AWS availability zones](https://howto.lintel.in/list-of-aws-regions-and-availability-zones/) within the region defined in `aws.region` . | Optional | `ap-southeast-2a, ap-southeast-2b` |
 | aws.cloudwatch.enable_log_subscription | This flag controls if you want to enable the cronjob to subscribe all Stacks Cloudwatch logs to the AEM Stack Manager Lambda function to stream the Cloudwatch Logs to S3. This flag enabled the cronjob `cloudwatch_s3_stream` on the component orchestrator.| Optional | `false` |
 | aws.cloudwatch.log_subscription_arn | The ARN of the AEM Stack Manager Lambda `cloudwatch logs s3 stream` function. | Optional | `` |
+| aws.cloudwatch.enable_cloudwatch_cleanup | This flag controls if all Cloudwatch Loggroups belonging to the AEM stack should get removed while deleting the AEM Stack. | Optional | `false` |
 | proxy.enabled | If true, then web proxy will be used during provisioning steps. Note: this web proxy setting is not used for cron jobs | Optional | `false` |
 | proxy.protocol | Web proxy server protocol used during provisioning steps | Optional | None |
 | proxy.host | Web proxy server host used during provisioning steps | Optional | None |

--- a/provisioners/ansible/playbooks/apps/aem/consolidated/main.yaml
+++ b/provisioners/ansible/playbooks/apps/aem/consolidated/main.yaml
@@ -89,3 +89,23 @@
         "stack_query.rc == 0"
       tags:
       - delete
+
+    - name: Retrieve all available cloudwatch groups to delete
+      cloudwatchlogs_log_group_facts:
+        log_group_name: "{{ stack_prefix }}"
+      register: loggroups_found
+      when:
+        "stack_query.rc == 0" and aws.cloudwatch.enable_cloudwatch_cleanup
+      tags:
+      - delete
+
+    - name: Delete Cloudwatch Loggroups
+      cloudwatchlogs_log_group:
+        state: absent
+        log_group_name: "{{ item.log_group_name}}"
+      with_items:
+        - "{{ loggroups_found.log_groups }}"
+      when:
+        "stack_query.rc == 0" and aws.cloudwatch.enable_cloudwatch_cleanup
+      tags:
+      - delete

--- a/provisioners/ansible/playbooks/apps/aem/full-set/main.yaml
+++ b/provisioners/ansible/playbooks/apps/aem/full-set/main.yaml
@@ -165,3 +165,23 @@
         "stack_query.rc == 0"
       tags:
       - delete
+
+    - name: Retrieve all available cloudwatch groups to delete
+      cloudwatchlogs_log_group_facts:
+        log_group_name: "{{ stack_prefix }}"
+      register: loggroups_found
+      when:
+        "stack_query.rc == 0" and aws.cloudwatch.enable_cloudwatch_cleanup
+      tags:
+      - delete
+
+    - name: Delete Cloudwatch Loggroups
+      cloudwatchlogs_log_group:
+        state: absent
+        log_group_name: "{{ item.log_group_name}}"
+      with_items:
+        - "{{ loggroups_found.log_groups }}"
+      when:
+        "stack_query.rc == 0" and aws.cloudwatch.enable_cloudwatch_cleanup
+      tags:
+      - delete


### PR DESCRIPTION
Add feature to enable removal of all available Cloudwatch Loggroups 
while deleting an AEM Stack [#366]