### PR TITLE
migrate Old SNS topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
-- Added CloudWatch alarms related to each component
-- Added alarms SNS topic prerequisites stack
-- Migrate old SNS topic to new one which support warning and critical conditions.
+- Add memory alarms across all AEM Full-Set components
+- Add Dispatcher data volume metric to monitoring stack's CloudWatch dashboard
+- Remove AEM Full-Set generic SNS topic, migrate existing alarms to Critical/Warning SNS topics
 
 ## 4.24.0 - 2019-12-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Added CloudWatch alarms related to each component
 - Added alarms SNS topic prerequisites stack
+- Migrate old SNS topic to new one which support warning and critical conditions.
 
 ## 4.24.0 - 2019-12-03
 ### Added

--- a/templates/cloudformation/apps/aem/full-set/author-dispatcher.yaml
+++ b/templates/cloudformation/apps/aem/full-set/author-dispatcher.yaml
@@ -242,15 +242,15 @@ Resources:
         Value:
           Ref: MainStackPrefixParameter
     Type: AWS::ElasticLoadBalancing::LoadBalancer
-  AuthorDispatcherAtLeastOneUnHealthyAlarm:
+  WarningAuthorDispatcherAtLeastOneUnHealthyAlarm:
     Properties:
       ActionsEnabled: true
       AlarmActions:
       - Fn::ImportValue:
-          Fn::Sub: ${PrerequisitesStackPrefixParameter}-AlarmNotificationTopic
+          Fn::Sub: ${PrerequisitesStackPrefixParameter}-WarningAlarmNotificationTopic
       AlarmDescription: At least one Author Dispatcher is Unhealthy
       AlarmName:
-        Fn::Sub: ${MainStackPrefixParameter}-AuthorDispatcherAtLeastOneUnHealthyAlarm
+        Fn::Sub: ${MainStackPrefixParameter}-Warning-AuthorDispatcher-AtLeastOneUnHealthyAlarm
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
       - Name: LoadBalancerName
@@ -261,20 +261,20 @@ Resources:
       Namespace: AWS/ELB
       OKActions:
       - Fn::ImportValue:
-          Fn::Sub: ${PrerequisitesStackPrefixParameter}-AlarmNotificationTopic
+          Fn::Sub: ${PrerequisitesStackPrefixParameter}-WarningAlarmNotificationTopic
       Period: 60
       Statistic: Average
       Threshold: 1
     Type: AWS::CloudWatch::Alarm
-  AuthorDispatcherMoreThanOneUnHealthyAlarm:
+  CriticalAuthorDispatcherMoreThanOneUnHealthyAlarm:
     Properties:
       ActionsEnabled: true
       AlarmActions:
       - Fn::ImportValue:
-          Fn::Sub: ${PrerequisitesStackPrefixParameter}-AlarmNotificationTopic
+          Fn::Sub: ${PrerequisitesStackPrefixParameter}-CriticalAlarmNotificationTopic
       AlarmDescription: More than one Author Dispatcher is Unhealthy
       AlarmName:
-        Fn::Sub: ${MainStackPrefixParameter}-AuthorDispatcherMoreThanOneUnHealthyAlarm
+        Fn::Sub: ${MainStackPrefixParameter}-Critical-AuthorDispatcher-MoreThanOneUnHealthyAlarm
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
       - Name: LoadBalancerName
@@ -285,7 +285,7 @@ Resources:
       Namespace: AWS/ELB
       OKActions:
       - Fn::ImportValue:
-          Fn::Sub: ${PrerequisitesStackPrefixParameter}-AlarmNotificationTopic
+          Fn::Sub: ${PrerequisitesStackPrefixParameter}-CriticalAlarmNotificationTopic
       Period: 60
       Statistic: Average
       Threshold: 1

--- a/templates/cloudformation/apps/aem/full-set/author.yaml
+++ b/templates/cloudformation/apps/aem/full-set/author.yaml
@@ -36,13 +36,13 @@ Outputs:
         Fn::Sub: ${MainStackPrefixParameter}-AuthorStandbyInstance
     Value:
       Ref: AuthorStandbyInstance
-  AuthorSyncDelayAlarm:
+  CriticalAuthorSyncDelayAlarm:
     Description: The Author Sync Delay Alarm
     Export:
       Name:
-        Fn::Sub: ${MainStackPrefixParameter}-AuthorSyncDelayAlarm
+        Fn::Sub: ${MainStackPrefixParameter}-CriticalAuthorSyncDelayAlarm
     Value:
-      Ref: AuthorSyncDelayAlarm
+      Ref: CriticalAuthorSyncDelayAlarm
 Parameters:
   AemAwsStackProvisionerVersionParameter:
     Description: AEM AWS Stack Provisioner version number
@@ -277,15 +277,15 @@ Resources:
             \ ${DataBucketNameParameter} ${MainStackPrefixParameter} author-standby\
             \ ${AemAwsStackProvisionerVersionParameter}\n"
     Type: AWS::EC2::Instance
-  AuthorSyncDelayAlarm:
+  CriticalAuthorSyncDelayAlarm:
     Properties:
       ActionsEnabled: true
       AlarmActions:
       - Fn::ImportValue:
-          Fn::Sub: ${PrerequisitesStackPrefixParameter}-AlarmNotificationTopic
+          Fn::Sub: ${PrerequisitesStackPrefixParameter}-CriticalAlarmNotificationTopic
       AlarmDescription: Monitors the sync delay between the Author Standby and the Author Primary
       AlarmName:
-        Fn::Sub: ${MainStackPrefixParameter}-AuthorSyncDelayAlarm
+        Fn::Sub: ${MainStackPrefixParameter}-Critical-Author-SyncDelayAlarm
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
       - Name: FixedDimension
@@ -303,15 +303,15 @@ Resources:
       Statistic: Maximum
       Threshold: 60
     Type: AWS::CloudWatch::Alarm
-  MultiAuthorInstanceAlarm:
+  CriticalMultiAuthorInstanceAlarm:
     Properties:
       ActionsEnabled: true
       AlarmActions:
       - Fn::ImportValue:
-          Fn::Sub: ${PrerequisitesStackPrefixParameter}-AlarmNotificationTopic
+          Fn::Sub: ${PrerequisitesStackPrefixParameter}-CriticalAlarmNotificationTopic
       AlarmDescription: Multiple Author Instances have Entered into Service
       AlarmName:
-        Fn::Sub: ${MainStackPrefixParameter}-MultiAuthorInstanceAlarm
+        Fn::Sub: ${MainStackPrefixParameter}-Critical-Author-MultiAuthorInstanceAlarm
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
       - Name: LoadBalancerName
@@ -322,20 +322,20 @@ Resources:
       Namespace: AWS/ELB
       OKActions:
       - Fn::ImportValue:
-          Fn::Sub: ${PrerequisitesStackPrefixParameter}-AlarmNotificationTopic
+          Fn::Sub: ${PrerequisitesStackPrefixParameter}-CriticalAlarmNotificationTopic
       Period: 60
       Statistic: Maximum
       Threshold: 1
     Type: AWS::CloudWatch::Alarm
-  NoAuthorInstanceAlarm:
+  CriticalNoAuthorInstanceAlarm:
     Properties:
       ActionsEnabled: true
       AlarmActions:
       - Fn::ImportValue:
-          Fn::Sub: ${PrerequisitesStackPrefixParameter}-AlarmNotificationTopic
+          Fn::Sub: ${PrerequisitesStackPrefixParameter}-CriticalAlarmNotificationTopic
       AlarmDescription: No Author Instance in Service
       AlarmName:
-        Fn::Sub: ${MainStackPrefixParameter}-NoAuthorInstanceAlarm
+        Fn::Sub: ${MainStackPrefixParameter}-Critical-Author-NoAuthorInstanceAlarm
       ComparisonOperator: LessThanOrEqualToThreshold
       Dimensions:
       - Name: LoadBalancerName
@@ -346,7 +346,7 @@ Resources:
       Namespace: AWS/ELB
       OKActions:
       - Fn::ImportValue:
-          Fn::Sub: ${PrerequisitesStackPrefixParameter}-AlarmNotificationTopic
+          Fn::Sub: ${PrerequisitesStackPrefixParameter}-CriticalAlarmNotificationTopic
       Period: 60
       Statistic: Average
       Threshold: 0

--- a/templates/cloudformation/apps/aem/full-set/chaos-monkey.yaml
+++ b/templates/cloudformation/apps/aem/full-set/chaos-monkey.yaml
@@ -151,15 +151,15 @@ Resources:
             \ ${DataBucketNameParameter} ${MainStackPrefixParameter} chaos-monkey\
             \ ${AemAwsStackProvisionerVersionParameter}\n"
     Type: AWS::AutoScaling::LaunchConfiguration
-  ChaosMonkeyNoInstanceAlarm:
+  WarningChaosMonkeyNoInstanceAlarm:
     Properties:
       ActionsEnabled: true
       AlarmActions:
       - Fn::ImportValue:
-          Fn::Sub: ${PrerequisitesStackPrefixParameter}-AlarmNotificationTopic
+          Fn::Sub: ${PrerequisitesStackPrefixParameter}-WarningAlarmNotificationTopic
       AlarmDescription: No Chaos Monkey Instance in Service
       AlarmName:
-        Fn::Sub: ${MainStackPrefixParameter}-ChaosMonkeyNoInstanceAlarm
+        Fn::Sub: ${MainStackPrefixParameter}-Warning-ChaosMonkey-NoInstanceAlarm
       ComparisonOperator: LessThanThreshold
       Dimensions:
       - Name: AutoScalingGroupName
@@ -170,7 +170,7 @@ Resources:
       Namespace: AWS/AutoScaling
       OKActions:
       - Fn::ImportValue:
-          Fn::Sub: ${PrerequisitesStackPrefixParameter}-AlarmNotificationTopic
+          Fn::Sub: ${PrerequisitesStackPrefixParameter}-WarningAlarmNotificationTopic
       Period: 60
       Statistic: Average
       Threshold: 1

--- a/templates/cloudformation/apps/aem/full-set/messaging.yaml
+++ b/templates/cloudformation/apps/aem/full-set/messaging.yaml
@@ -33,13 +33,6 @@ Outputs:
         Fn::Sub: ${PrerequisitesStackPrefixParameter}-WarningAlarmNotificationTopic
     Value:
       Ref: WarningAlarmNotificationTopic
-  AlarmNotificationTopic:
-    Description: The AEM Alarm Notification Topic
-    Export:
-      Name:
-        Fn::Sub: ${PrerequisitesStackPrefixParameter}-AlarmNotificationTopic
-    Value:
-      Ref: AlarmNotificationTopic
 Parameters:
   AEMASGEventQueueNameParameter:
     Description: The AEM Stack Auto Scaling Group Event Quene Name
@@ -57,11 +50,11 @@ Parameters:
     Description: The AEM Stack Prerequisite Resources Stack Prefix
     Type: String
 Resources:
-  AEMASGEventQueueLengthHighAlarm:
+  CriticalAEMASGEventQueueLengthHighAlarm:
     Properties:
       ActionsEnabled: true
       AlarmActions:
-      - Ref: AlarmNotificationTopic
+      - Ref: CriticalAlarmNotificationTopic
       AlarmDescription: Alarm if queue length avg > 10 for 2 minutes
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
@@ -141,13 +134,4 @@ Resources:
             Ref: AEMCWEventNotificationEmail
           Protocol: email
         - Ref: AWS::NoValue
-    Type: AWS::SNS::Topic
-  AlarmNotificationTopic:
-    Properties:
-      DisplayName:
-        Fn::Sub: ${PrerequisitesStackPrefixParameter}-alarm-notification-topic
-      Subscription:
-      - Endpoint:
-          Ref: AEMCWEventNotificationEmail
-        Protocol: email
     Type: AWS::SNS::Topic

--- a/templates/cloudformation/apps/aem/full-set/orchestrator.yaml
+++ b/templates/cloudformation/apps/aem/full-set/orchestrator.yaml
@@ -183,15 +183,15 @@ Resources:
             \ ${DataBucketNameParameter} ${MainStackPrefixParameter} orchestrator\
             \ ${AemAwsStackProvisionerVersionParameter} /opt/shinesolutions/aem-aws-stack-builder/extra_local.yaml\n"
     Type: AWS::AutoScaling::LaunchConfiguration
-  OrchestratorNoInstanceAlarm:
+  CriticalOrchestratorNoInstanceAlarm:
     Properties:
       ActionsEnabled: true
       AlarmActions:
       - Fn::ImportValue:
-          Fn::Sub: ${PrerequisitesStackPrefixParameter}-AlarmNotificationTopic
+          Fn::Sub: ${PrerequisitesStackPrefixParameter}-CriticalAlarmNotificationTopic
       AlarmDescription: No Orchestrator Instance in Service
       AlarmName:
-        Fn::Sub: ${MainStackPrefixParameter}-OrchestratorNoInstanceAlarm
+        Fn::Sub: ${MainStackPrefixParameter}-Critical-Orchestrator-NoInstanceAlarm
       ComparisonOperator: LessThanThreshold
       Dimensions:
       - Name: AutoScalingGroupName
@@ -202,7 +202,7 @@ Resources:
       Namespace: AWS/AutoScaling
       OKActions:
       - Fn::ImportValue:
-          Fn::Sub: ${PrerequisitesStackPrefixParameter}-AlarmNotificationTopic
+          Fn::Sub: ${PrerequisitesStackPrefixParameter}-CriticalAlarmNotificationTopic
       Period: 60
       Statistic: Average
       Threshold: 1

--- a/templates/cloudformation/apps/aem/full-set/publish-dispatcher.yaml
+++ b/templates/cloudformation/apps/aem/full-set/publish-dispatcher.yaml
@@ -165,10 +165,14 @@ Resources:
         - Fn::ImportValue:
             Fn::Sub: ${NetworkStackPrefixParameter}-PublishDispatcherSubnetList
     Type: AWS::AutoScaling::AutoScalingGroup
-  PublishDispatcherCPUHighAlarm:
+  CriticalPublishDispatcherAVGCPUHighAlarm:
     Properties:
+      AlarmName:
+        Fn::Sub: ${MainStackPrefixParameter}-Critical-PublishDispatcher-AVGCPUHighAlarm
       AlarmActions:
       - Ref: PublishDispatcherScaleUpPolicy
+      - Fn::ImportValue:
+          Fn::Sub: ${PrerequisitesStackPrefixParameter}-CriticalAlarmNotificationTopic
       AlarmDescription: Scale up if CPU Avg > X % for X minutes
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
@@ -192,10 +196,14 @@ Resources:
           - Ref: PublishDispatcherASGCPUScalingParameters
       TreatMissingData: breaching
     Type: AWS::CloudWatch::Alarm
-  PublishDispatcherCPULowAlarm:
+  WarningPublishDispatcherAVGCPULowAlarm:
     Properties:
+      AlarmName:
+        Fn::Sub: ${MainStackPrefixParameter}-Warning-PublishDispatcher-AVGCPULowAlarm
       AlarmActions:
       - Ref: PublishDispatcherScaleDownPolicy
+      - Fn::ImportValue:
+          Fn::Sub: ${PrerequisitesStackPrefixParameter}-WarningAlarmNotificationTopic
       AlarmDescription: Scale down if CPU Avg < X % for X minutes
       ComparisonOperator: LessThanThreshold
       Dimensions:
@@ -219,15 +227,15 @@ Resources:
           - Ref: PublishDispatcherASGCPUScalingParameters
       TreatMissingData: breaching
     Type: AWS::CloudWatch::Alarm
-  PublishDispatcherAtLeastOneUnHealthyAlarm:
+  WarningPublishDispatcherAtLeastOneUnHealthyAlarm:
     Properties:
       ActionsEnabled: true
       AlarmActions:
       - Fn::ImportValue:
-          Fn::Sub: ${PrerequisitesStackPrefixParameter}-AlarmNotificationTopic
+          Fn::Sub: ${PrerequisitesStackPrefixParameter}-WarningAlarmNotificationTopic
       AlarmDescription: At least one Publish Dispatcher is Unhealthy
       AlarmName:
-        Fn::Sub: ${MainStackPrefixParameter}-PublishDispatcherAtLeastOneUnHealthyAlarm
+        Fn::Sub: ${MainStackPrefixParameter}-Warning-PublishDispatcher-AtLeastOneUnHealthyAlarm
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
       - Name: LoadBalancerName
@@ -238,20 +246,20 @@ Resources:
       Namespace: AWS/ELB
       OKActions:
       - Fn::ImportValue:
-          Fn::Sub: ${PrerequisitesStackPrefixParameter}-AlarmNotificationTopic
+          Fn::Sub: ${PrerequisitesStackPrefixParameter}-WarningAlarmNotificationTopic
       Period: 60
       Statistic: Average
       Threshold: 1
     Type: AWS::CloudWatch::Alarm
-  PublishDispatcherMoreThanOneUnHealthyAlarm:
+  CriticalPublishDispatcherMoreThanOneUnHealthyAlarm:
     Properties:
       ActionsEnabled: true
       AlarmActions:
       - Fn::ImportValue:
-          Fn::Sub: ${PrerequisitesStackPrefixParameter}-AlarmNotificationTopic
+          Fn::Sub: ${PrerequisitesStackPrefixParameter}-CriticalAlarmNotificationTopic
       AlarmDescription: More than one Publish Dispatcher is Unhealthy
       AlarmName:
-        Fn::Sub: ${MainStackPrefixParameter}-PublishDispatcherMoreThanOneUnHealthyAlarm
+        Fn::Sub: ${MainStackPrefixParameter}-Critical-PublishDispatcher-MoreThanOneUnHealthyAlarm
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
       - Name: LoadBalancerName
@@ -262,7 +270,7 @@ Resources:
       Namespace: AWS/ELB
       OKActions:
       - Fn::ImportValue:
-          Fn::Sub: ${PrerequisitesStackPrefixParameter}-AlarmNotificationTopic
+          Fn::Sub: ${PrerequisitesStackPrefixParameter}-CriticalAlarmNotificationTopic
       Period: 60
       Statistic: Average
       Threshold: 1


### PR DESCRIPTION
Old SNS Topic had been completely remove and  new warning and  critical topics will be used.