### PR TITLE
Fix for switch dns failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add feature to define CMK for SSE SNS Topic & SNS Queue encryption [#370]
 - Add Monitoring Stack to AEM Full-Set permission type c
 
+### Fixed
+- Add boto library, which is required for the Ansible switch dns module
+- Update boto3 and botocore verison to fix incompatible pip installation error
+- Remove stack_prefix in consolidated switch dns pipeline since stack_prefix is included in the recordset config
+
 ### Changed
 - Configuration parameters `[aem_component].enable_vol_encryption` are now deprecated and replaced with `aws.encryption.ebs_volume.enable` [#371]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add boto library, which is required for the Ansible switch dns module
 
-### Changd
+### Changed
 - Update boto3 and botocore verison to fix incompatible pip installation error
-
-### Removed
-- Remove stack_prefix in consolidated switch dns pipeline since stack_prefix is included in the recordset config
 
 ## 4.33.0 - 2020-02-09
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Add boto library, which is required for the Ansible switch dns module
+
+### Changd
+- Update boto3 and botocore verison to fix incompatible pip installation error
+
+### Removed
+- Remove stack_prefix in consolidated switch dns pipeline since stack_prefix is included in the recordset config
+
 ## 4.33.0 - 2020-02-09
 ### Added
 - Add new configuration parameter `aws.encryption.ebs_volume.enable` to enable EBS Volume encryption#370
@@ -18,11 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add feature to define CMK for SSE S3 Buckets encryption [#370]
 - Add feature to define CMK for SSE SNS Topic & SNS Queue encryption [#370]
 - Add Monitoring Stack to AEM Full-Set permission type c
-
-### Fixed
-- Add boto library, which is required for the Ansible switch dns module
-- Update boto3 and botocore verison to fix incompatible pip installation error
-- Remove stack_prefix in consolidated switch dns pipeline since stack_prefix is included in the recordset config
 
 ### Changed
 - Configuration parameters `[aem_component].enable_vol_encryption` are now deprecated and replaced with `aws.encryption.ebs_volume.enable` [#371]

--- a/provisioners/ansible/playbooks/apps/aem/consolidated/switch-dns.yaml
+++ b/provisioners/ansible/playbooks/apps/aem/consolidated/switch-dns.yaml
@@ -50,7 +50,7 @@
         private_zone : "{{ 'yes' if ([author_publish_dispatcher_hosted_zone_private.stdout][0]) == 'true' else 'no' }}"
         zone: "{{ sanitise_author_dispatcher_hosted_zone.msg[0] }}"
         record: '{{ sanitise_author_publish_dispatcher_record_set.msg[0] }}'
-        value: "{{ dns_records.author_publish_dispatcher.record_set_name }}.{{ sanitise_author_dispatcher_hosted_zone.msg[0] }}"
+        value: "{{ stack_prefix }}-{{ dns_records.author_publish_dispatcher.record_set_name }}.{{ sanitise_author_dispatcher_hosted_zone.msg[0] }}"
         overwrite: yes
         type: "{{ author_publish_dispatcher_record_type.stdout | regex_replace('\"', '') }}"
       tags: switch

--- a/provisioners/ansible/playbooks/apps/aem/consolidated/switch-dns.yaml
+++ b/provisioners/ansible/playbooks/apps/aem/consolidated/switch-dns.yaml
@@ -50,7 +50,7 @@
         private_zone : "{{ 'yes' if ([author_publish_dispatcher_hosted_zone_private.stdout][0]) == 'true' else 'no' }}"
         zone: "{{ sanitise_author_dispatcher_hosted_zone.msg[0] }}"
         record: '{{ sanitise_author_publish_dispatcher_record_set.msg[0] }}'
-        value: "{{ stack_prefix }}-{{ dns_records.author_publish_dispatcher.record_set_name }}.{{ sanitise_author_dispatcher_hosted_zone.msg[0] }}"
+        value: "{{ dns_records.author_publish_dispatcher.record_set_name }}.{{ sanitise_author_dispatcher_hosted_zone.msg[0] }}"
         overwrite: yes
         type: "{{ author_publish_dispatcher_record_type.stdout | regex_replace('\"', '') }}"
       tags: switch

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 ansible==2.9.2
-botocore==1.13.40
-boto3==1.10.35
 awscli==1.16.304
+boto==2.49.0
+boto3==1.10.35
+botocore==1.13.40
 jinja2==2.10.3
 pylint==1.9.5
 ruamel.yaml==0.16.5
 yamllint==1.19.0
-boto==2.49.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 ansible==2.9.2
+botocore==1.13.40
+boto3==1.10.35
 awscli==1.16.304
-boto3==1.10.41
 jinja2==2.10.3
 pylint==1.9.5
 ruamel.yaml==0.16.5
 yamllint==1.19.0
+boto==2.49.0


### PR DESCRIPTION
1. Add boto library, which is required for the Ansible switch dns module
2. Update boto3 and botocore verison to fix incompatible pip installation error