### PR TITLE
[#378] Add missing Stack output parameter for full-set permission type c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Add missing CF Stack output parameter for full-set permission type c [#378]
+
 ## 4.35.0 - 2020-03-01
 ### Added
 - Add support for Dispatcher Data volume device to consolidated [#379]

--- a/templates/cloudformation/apps/aem/full-set/prerequisites-c.yaml
+++ b/templates/cloudformation/apps/aem/full-set/prerequisites-c.yaml
@@ -30,6 +30,13 @@ Outputs:
         Fn::Sub: ${PrerequisitesStackPrefixParameter}-SecurityGroupsStackName
     Value:
       Ref: SecurityGroupsStack
+  AWSAccountID:
+    Description: AWS Account ID
+    Export:
+      Name:
+        Fn::Sub: ${PrerequisitesStackPrefixParameter}-AWSAccountId
+    Value:
+      Ref: AWS::AccountId
 Parameters:
   AEMASGEventQueueNameParameter:
     Description: The AEM Stack Auto Scaling Group Event Quene Name


### PR DESCRIPTION
### Added
- Add missing CF Stack output parameter for full-set permission type c 
[#378]