### PR TITLE
Set the default region environment variable before running the readiness test

### DIFF
--- a/templates/cloudformation/apps/aem-stack-manager/ssm-commands/AEM-TestReadinessFullset.yaml
+++ b/templates/cloudformation/apps/aem-stack-manager/ssm-commands/AEM-TestReadinessFullset.yaml
@@ -17,6 +17,7 @@ mainSteps:
     inputs:
       runCommand:
         - '. /etc/profile'
+        - 'export AWS_DEFAULT_REGION=$(aws configure get region)'
         - 'while [ ! -f /opt/shinesolutions/aem-aws-stack-builder/stack-init-completed ]; do sleep 15; echo "Waiting for component initialisation to complete..."; done'
         - /opt/shinesolutions/aem-tools/test-readiness.sh
       timeoutSeconds: '{{ executionTimeout }}'


### PR DESCRIPTION
Set the default region environment variable before running the readiness test, to avoid ruby_aem_aws defaulting to ap-southeast-2.

This is in relation to https://github.com/shinesolutions/ruby_aem_aws/pull/28 and is the workaround I used to successfully deploy a full-set on a different region. I submit it here in case you want to review it.

As I mentioned in my other comment, perhaps a more proper solution would be to change inspec_aem_aws to support reading the region variable from the user config and then passing it to ruby_aem_aws but this would require more changes in multiple places.
