### PR TITLE
Add support `aws_region` support to stack-`init` script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Tagging support to AEM Stack Manager DynamoDB
 - Add Tagging support to AOC managed S3 Bucket
 - Add boto library, which is required for the Ansible switch dns module
+- Add `aws_region` support for `stack-init` script [shinesolutions/aem-opencloud-manager#65]
 
 ### Changed
 - Update boto3 and botocore verison to fix incompatible pip installation error

--- a/scripts/stack-init.sh
+++ b/scripts/stack-init.sh
@@ -130,8 +130,11 @@ export FACTER_data_bucket_name="${data_bucket_name}"
 export FACTER_stack_prefix="${stack_prefix}"
 aws_region=$(facter aws_region)
 
+export AWS_DEFAULT_REGION="${aws_region}"
+echo "AWS Region: ${AWS_DEFAULT_REGION}"
+
 # Set ec2 instance tag that provisioning is InProgress
-AWS_DEFAULT_REGION="${aws_region}" aws ec2 create-tags --resources "${instance_id}" --tags Key=ComponentInitStatus,Value=InProgress
+aws ec2 create-tags --resources "${instance_id}" --tags Key=ComponentInitStatus,Value=InProgress
 handle_exit_code "$?"
 
 if aws s3api head-object --bucket "${data_bucket_name}" --key "${stack_prefix}/aem-custom-stack-provisioner.tar.gz" > /dev/null 2>&1; then


### PR DESCRIPTION
### Added
Add `aws_region` support for `stack-init` script 
shinesolutions/aem-opencloud-manager#65