### PR TITLE
Update stack-init script to change dir to custom-stack-provisioner path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Upgrade AEM AWS Stack Provisioner to 4.32.0
 
+### Changed
+- Update stack-init script to change dir to custom-stack-provisioner path
+
 ## 4.36.1 - 2020-03-13
 ### Fixed
 - Fix incorrect version number for AEM AWS Stack Provisioner upgrade to 4.31.0

--- a/scripts/stack-init.sh
+++ b/scripts/stack-init.sh
@@ -62,9 +62,13 @@ run_custom_stage() {
   if [ -x "${script}" ]; then
     set +o errexit
 
+    cd ${custom_provisioner_dir}
+
     echo "${label} Executing the ${stage} script of Custom Stack Provisioner..."
     "${script}" "${stack_prefix}" "${component}" >> "${log_dir}/custom-stack-init-${stage}.log"
     handle_exit_code "$?"
+
+    cd "${aws_provisioner_dir}"
 
     set -o errexit
   else


### PR DESCRIPTION
This PR will add two additional steps to the stack-init process:

1. Change dir to the custom-stack-provisioner dir before the execution of the custom-stack-provisioner
2. Change dir back to the aem-aws-stack-provisioner dir after the exeuction of the custom-stack-provisioner

This is necessary because the user is expecting to be in the directory of the custom-stack-provisioner when the custom-stack-provisioner gets executed and therefore the user can use regular mechanisms to determine the path of the current dir.