### PR TITLE
Update configuration parameter value for asg_cooldown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Changed default value for `[publish_dispatcher|publish|author_dispatcher].asg_cooldown` to `[publish_dispatcher|publish|author_dispatcher].asg_health_check_grace_period` + 5 minutes to increase stack reliability in events of high load
+
 ## 4.39.0 - 2020-04-15
 ### Changed
 - Upgrade AEM AWS Stack Provisioner to 4.34.0

--- a/conf/ansible/inventory/group_vars/apps.yaml
+++ b/conf/ansible/inventory/group_vars/apps.yaml
@@ -286,7 +286,7 @@ publish_dispatcher:
   asg_desired_capacity: 2
   asg_max_size: 2
   asg_health_check_grace_period: 2400
-  asg_cooldown: 480
+  asg_cooldown: 2700
   asg_cpu_scaling_threshold: 49
   asg_cpu_high_period: 300
   asg_cpu_high_eval_period: 1
@@ -304,7 +304,7 @@ publish:
   asg_desired_capacity: 2
   asg_max_size: 2
   asg_health_check_grace_period: 1800
-  asg_cooldown: 480
+  asg_cooldown: 2280
 
 author:
   instance_profile: overwrite-me
@@ -326,7 +326,7 @@ author_dispatcher:
   asg_desired_capacity: 2
   asg_max_size: 2
   asg_health_check_grace_period: 900
-  asg_cooldown: 480
+  asg_cooldown: 1380
 
 author_publish_dispatcher:
   instance_profile: overwrite-me

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -260,3 +260,11 @@ To create a stack with the old FS structure you need AMIs created with Packer-AE
 
 - **Q:** Is there any risk of having a dead replication agent? (replication agent which points to an inexisting instance)<br>
   **A:** Yes. A dead replication agent can contain some items in its queue, but they will never be cleared from the queue because the destination instance doesn't exist. This condition will cause AEM Health Check to fail, with the `ReplicationQueueHealthCheck` having non `OK` status, and this will cause AEM provisioning to fail.
+
+- **Q:** How to avoid flipping of the AEM Publish/Publish-Dispatcher instances when the AEM stack is under heavy load ?<br>
+  **A:** If your AEM Stack is continuously under heavy load you may experience that the Publish-Dispatcher ASG is scaling up and down (flipping) which in a worst case will lead to that no Publish/Publish-Dispatcher is healthy to serve content. This behaviour is due to a too low configured `publish_dispatcher.asg_cooldown`.  
+
+  To avoid the likelihood of this scenario it's recommended to increase this value to a higher value than configured at
+  `publish_dispatcher.asg_health_check_grace_period`. As a rule of thumb use `publish_dispatcher.asg_health_check_grace_period` + 5 minutes.
+
+  This will give the ASG sufficient time to determine the state of the new instance and react if not healthy.


### PR DESCRIPTION
### Changed
- Changed default value for 
`[publish_dispatcher|publish|author_dispatcher].asg_cooldown` to 
`[publish_dispatcher|publish|author_dispatcher].asg_health_check_grace_period` 
+ 5 minutes to increase stack reliability in events of high load