### PR TITLE
Add custom CIPHER to Full-Set ELB to disable insecure SSL Protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed Stack deletion process for **permission-type c** when AWS resource encryption via CMK is enabled[#407]
 
+### Changed
+- Changed default parameter `compute.elb_cipher_suite` to `AOCELBSecurityPolicy-TLS-1-2-2017-01`
+- Disable TLS 1.0 & TLS 1.1 support for Author-Dispatcher, Publish-Dispatcher & Author ELB
+
 ## 4.40.0 - 2020-05-14
 ### Added
 - Added new parameters to parameterise Publish-Dispatcher ASG Scaling policies cooldown timer [#405]

--- a/conf/ansible/inventory/group_vars/apps.yaml
+++ b/conf/ansible/inventory/group_vars/apps.yaml
@@ -146,8 +146,7 @@ messaging:
 
 compute:
   key_pair_name: overwrite-me
-  # TODO: switch to ELBSecurityPolicy-TLS-1-2-2017-01 after upgrading deps
-  elb_cipher_suite: ELBSecurityPolicy-2016-08
+  elb_cipher_suite: AOCELBSecurityPolicy-TLS-1-2-2017-01
 
 s3:
   data_bucket_name: overwrite-me

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -124,6 +124,7 @@ These configurations are applicable to AWS resources used by the AEM environment
 | messaging.alarm_notification.contact_email | Recipient email address where AEM Full-Set alarm notification will be sent to.  | Optional | |
 | messaging.alarm_notification.https_endpoint | Notification https endpoint where AEM Full-Set alarm notification will be sent to.  | Optional | |
 | compute.key_pair_name | [EC2 key pair](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) to be provisioned on all EC2 instances within the AEM environment. | Mandatory | |
+| compute.elb_cipher_suite | Cipher to use for the AEM Full-Set Author-Dispatcher, Publish-Dispatcher & Author ELB. Default parameter is a 1:1 copy of AWS default SSL policy `ELBSecurityPolicy-TLS-1-2-2017-01`| optional | `AOCELBSecurityPolicy-TLS-1-2-2017-01` |
 | s3.data_bucket_name | S3 data bucket which stores all AEM environment's object files such as descriptors and credentials. | Mandatory | |
 | s3.create_bucket_flag | If "true", an S3 bucket with name: `s3.data_bucket_name` will be created as part of `make create-aws-resources` | Optional | "true" |
 | dns_records.create_hosted_zone_flag | If "true", a Route53 Private HostedZone with name: `dns_records.route53_hosted_zone_name` will be created as part of `make create-aws-resources` | Optional | "true" |

--- a/templates/cloudformation/apps/aem/full-set/author-dispatcher.yaml
+++ b/templates/cloudformation/apps/aem/full-set/author-dispatcher.yaml
@@ -287,6 +287,196 @@ Resources:
           Ref: AuthorDispatcherLoadBalancerHealthCheckTargetParameter
         Timeout: '5'
         UnhealthyThreshold: '2'
+      Policies:
+      - PolicyName: AOCELBSecurityPolicy-TLS-1-2-2017-01
+        PolicyType: SSLNegotiationPolicyType
+        Attributes:
+        - Name: Protocol-SSLv3
+          Value: "false"
+        - Name: Protocol-TLSv1
+          Value: "false"
+        - Name: Protocol-TLSv1.1
+          Value: "false"
+        - Name: Protocol-TLSv1.2
+          Value: "true"
+        - Name: Server-Defined-Cipher-Order
+          Value: "true"
+        - Name: ECDHE-ECDSA-AES128-GCM-SHA256
+          Value: "true"
+        - Name: ECDHE-RSA-AES128-GCM-SHA256
+          Value: "true"
+        - Name: ECDHE-ECDSA-AES128-SHA256
+          Value: "true"
+        - Name: ECDHE-RSA-AES128-SHA256
+          Value: "true"
+        - Name: ECDHE-ECDSA-AES128-SHA
+          Value: "false"
+        - Name: ECDHE-RSA-AES128-SHA
+          Value: "false"
+        - Name: DHE-RSA-AES128-SHA
+          Value: "false"
+        - Name: ECDHE-ECDSA-AES256-GCM-SHA384
+          Value: "true"
+        - Name: ECDHE-RSA-AES256-GCM-SHA384
+          Value: "true"
+        - Name: ECDHE-ECDSA-AES256-SHA384
+          Value: "true"
+        - Name: ECDHE-RSA-AES256-SHA384
+          Value: "true"
+        - Name: ECDHE-RSA-AES256-SHA
+          Value: "false"
+        - Name: ECDHE-ECDSA-AES256-SHA
+          Value: "false"
+        - Name: AES128-GCM-SHA256
+          Value: "true"
+        - Name: AES128-SHA256
+          Value: "true"
+        - Name: AES128-SHA
+          Value: "false"
+        - Name: AES256-GCM-SHA384
+          Value: "true"
+        - Name: AES256-SHA256
+          Value: "true"
+        - Name: AES256-SHA
+          Value: "false"
+        - Name: DHE-DSS-AES128-SHA
+          Value: "false"
+        - Name: CAMELLIA128-SHA
+          Value: "false"
+        - Name: EDH-RSA-DES-CBC3-SHA
+          Value: "false"
+        - Name: DES-CBC3-SHA
+          Value: "false"
+        - Name: ECDHE-RSA-RC4-SHA
+          Value: "false"
+        - Name: RC4-SHA
+          Value: "false"
+        - Name: ECDHE-ECDSA-RC4-SHA
+          Value: "false"
+        - Name: DHE-DSS-AES256-GCM-SHA384
+          Value: "false"
+        - Name: DHE-RSA-AES256-GCM-SHA384
+          Value: "false"
+        - Name: DHE-RSA-AES256-SHA256
+          Value: "false"
+        - Name: DHE-DSS-AES256-SHA256
+          Value: "false"
+        - Name: DHE-RSA-AES256-SHA
+          Value: "false"
+        - Name: DHE-DSS-AES256-SHA
+          Value: "false"
+        - Name: DHE-RSA-CAMELLIA256-SHA
+          Value: "false"
+        - Name: DHE-DSS-CAMELLIA256-SHA
+          Value: "false"
+        - Name: CAMELLIA256-SHA
+          Value: "false"
+        - Name: EDH-DSS-DES-CBC3-SHA
+          Value: "false"
+        - Name: DHE-DSS-AES128-GCM-SHA256
+          Value: "false"
+        - Name: DHE-RSA-AES128-GCM-SHA256
+          Value: "false"
+        - Name: DHE-RSA-AES128-SHA256
+          Value: "false"
+        - Name: DHE-DSS-AES128-SHA256
+          Value: "false"
+        - Name: DHE-RSA-CAMELLIA128-SHA
+          Value: "false"
+        - Name: DHE-DSS-CAMELLIA128-SHA
+          Value: "false"
+        - Name: ADH-AES128-GCM-SHA256
+          Value: "false"
+        - Name: ADH-AES128-SHA
+          Value: "false"
+        - Name: ADH-AES128-SHA256
+          Value: "false"
+        - Name: ADH-AES256-GCM-SHA384
+          Value: "false"
+        - Name: ADH-AES256-SHA
+          Value: "false"
+        - Name: ADH-AES256-SHA256
+          Value: "false"
+        - Name: ADH-CAMELLIA128-SHA
+          Value: "false"
+        - Name: ADH-CAMELLIA256-SHA
+          Value: "false"
+        - Name: ADH-DES-CBC3-SHA
+          Value: "false"
+        - Name: ADH-DES-CBC-SHA
+          Value: "false"
+        - Name: ADH-RC4-MD5
+          Value: "false"
+        - Name: ADH-SEED-SHA
+          Value: "false"
+        - Name: DES-CBC-SHA
+          Value: "false"
+        - Name: DHE-DSS-SEED-SHA
+          Value: "false"
+        - Name: DHE-RSA-SEED-SHA
+          Value: "false"
+        - Name: EDH-DSS-DES-CBC-SHA
+          Value: "false"
+        - Name: EDH-RSA-DES-CBC-SHA
+          Value: "false"
+        - Name: IDEA-CBC-SHA
+          Value: "false"
+        - Name: RC4-MD5
+          Value: "false"
+        - Name: SEED-SHA
+          Value: "false"
+        - Name: DES-CBC3-MD5
+          Value: "false"
+        - Name: DES-CBC-MD5
+          Value: "false"
+        - Name: RC2-CBC-MD5
+          Value: "false"
+        - Name: PSK-AES256-CBC-SHA
+          Value: "false"
+        - Name: PSK-3DES-EDE-CBC-SHA
+          Value: "false"
+        - Name: KRB5-DES-CBC3-SHA
+          Value: "false"
+        - Name: KRB5-DES-CBC3-MD5
+          Value: "false"
+        - Name: PSK-AES128-CBC-SHA
+          Value: "false"
+        - Name: PSK-RC4-SHA
+          Value: "false"
+        - Name: KRB5-RC4-SHA
+          Value: "false"
+        - Name: KRB5-RC4-MD5
+          Value: "false"
+        - Name: KRB5-DES-CBC-SHA
+          Value: "false"
+        - Name: KRB5-DES-CBC-MD5
+          Value: "false"
+        - Name: EXP-EDH-RSA-DES-CBC-SHA
+          Value: "false"
+        - Name: EXP-EDH-DSS-DES-CBC-SHA
+          Value: "false"
+        - Name: EXP-ADH-DES-CBC-SHA
+          Value: "false"
+        - Name: EXP-DES-CBC-SHA
+          Value: "false"
+        - Name: EXP-RC2-CBC-MD5
+          Value: "false"
+        - Name: EXP-KRB5-RC2-CBC-SHA
+          Value: "false"
+        - Name: EXP-KRB5-DES-CBC-SHA
+          Value: "false"
+        - Name: EXP-KRB5-RC2-CBC-MD5
+          Value: "false"
+        - Name: EXP-KRB5-DES-CBC-MD5
+          Value: "false"
+        - Name: EXP-ADH-RC4-MD5
+          Value: "false"
+        - Name: EXP-RC4-MD5
+          Value: "false"
+        - Name: EXP-KRB5-RC4-SHA
+          Value: "false"
+        - Name: EXP-KRB5-RC4-MD5
+          Value: "false"
       Listeners:
       - InstancePort: '80'
         LoadBalancerPort: '80'

--- a/templates/cloudformation/apps/aem/full-set/author.yaml
+++ b/templates/cloudformation/apps/aem/full-set/author.yaml
@@ -146,6 +146,196 @@ Resources:
       Instances:
       - Ref: AuthorPrimaryInstance
       - Ref: AuthorStandbyInstance
+      Policies:
+      - PolicyName: AOCELBSecurityPolicy-TLS-1-2-2017-01
+        PolicyType: SSLNegotiationPolicyType
+        Attributes:
+        - Name: Protocol-SSLv3
+          Value: "false"
+        - Name: Protocol-TLSv1
+          Value: "false"
+        - Name: Protocol-TLSv1.1
+          Value: "false"
+        - Name: Protocol-TLSv1.2
+          Value: "true"
+        - Name: Server-Defined-Cipher-Order
+          Value: "true"
+        - Name: ECDHE-ECDSA-AES128-GCM-SHA256
+          Value: "true"
+        - Name: ECDHE-RSA-AES128-GCM-SHA256
+          Value: "true"
+        - Name: ECDHE-ECDSA-AES128-SHA256
+          Value: "true"
+        - Name: ECDHE-RSA-AES128-SHA256
+          Value: "true"
+        - Name: ECDHE-ECDSA-AES128-SHA
+          Value: "false"
+        - Name: ECDHE-RSA-AES128-SHA
+          Value: "false"
+        - Name: DHE-RSA-AES128-SHA
+          Value: "false"
+        - Name: ECDHE-ECDSA-AES256-GCM-SHA384
+          Value: "true"
+        - Name: ECDHE-RSA-AES256-GCM-SHA384
+          Value: "true"
+        - Name: ECDHE-ECDSA-AES256-SHA384
+          Value: "true"
+        - Name: ECDHE-RSA-AES256-SHA384
+          Value: "true"
+        - Name: ECDHE-RSA-AES256-SHA
+          Value: "false"
+        - Name: ECDHE-ECDSA-AES256-SHA
+          Value: "false"
+        - Name: AES128-GCM-SHA256
+          Value: "true"
+        - Name: AES128-SHA256
+          Value: "true"
+        - Name: AES128-SHA
+          Value: "false"
+        - Name: AES256-GCM-SHA384
+          Value: "true"
+        - Name: AES256-SHA256
+          Value: "true"
+        - Name: AES256-SHA
+          Value: "false"
+        - Name: DHE-DSS-AES128-SHA
+          Value: "false"
+        - Name: CAMELLIA128-SHA
+          Value: "false"
+        - Name: EDH-RSA-DES-CBC3-SHA
+          Value: "false"
+        - Name: DES-CBC3-SHA
+          Value: "false"
+        - Name: ECDHE-RSA-RC4-SHA
+          Value: "false"
+        - Name: RC4-SHA
+          Value: "false"
+        - Name: ECDHE-ECDSA-RC4-SHA
+          Value: "false"
+        - Name: DHE-DSS-AES256-GCM-SHA384
+          Value: "false"
+        - Name: DHE-RSA-AES256-GCM-SHA384
+          Value: "false"
+        - Name: DHE-RSA-AES256-SHA256
+          Value: "false"
+        - Name: DHE-DSS-AES256-SHA256
+          Value: "false"
+        - Name: DHE-RSA-AES256-SHA
+          Value: "false"
+        - Name: DHE-DSS-AES256-SHA
+          Value: "false"
+        - Name: DHE-RSA-CAMELLIA256-SHA
+          Value: "false"
+        - Name: DHE-DSS-CAMELLIA256-SHA
+          Value: "false"
+        - Name: CAMELLIA256-SHA
+          Value: "false"
+        - Name: EDH-DSS-DES-CBC3-SHA
+          Value: "false"
+        - Name: DHE-DSS-AES128-GCM-SHA256
+          Value: "false"
+        - Name: DHE-RSA-AES128-GCM-SHA256
+          Value: "false"
+        - Name: DHE-RSA-AES128-SHA256
+          Value: "false"
+        - Name: DHE-DSS-AES128-SHA256
+          Value: "false"
+        - Name: DHE-RSA-CAMELLIA128-SHA
+          Value: "false"
+        - Name: DHE-DSS-CAMELLIA128-SHA
+          Value: "false"
+        - Name: ADH-AES128-GCM-SHA256
+          Value: "false"
+        - Name: ADH-AES128-SHA
+          Value: "false"
+        - Name: ADH-AES128-SHA256
+          Value: "false"
+        - Name: ADH-AES256-GCM-SHA384
+          Value: "false"
+        - Name: ADH-AES256-SHA
+          Value: "false"
+        - Name: ADH-AES256-SHA256
+          Value: "false"
+        - Name: ADH-CAMELLIA128-SHA
+          Value: "false"
+        - Name: ADH-CAMELLIA256-SHA
+          Value: "false"
+        - Name: ADH-DES-CBC3-SHA
+          Value: "false"
+        - Name: ADH-DES-CBC-SHA
+          Value: "false"
+        - Name: ADH-RC4-MD5
+          Value: "false"
+        - Name: ADH-SEED-SHA
+          Value: "false"
+        - Name: DES-CBC-SHA
+          Value: "false"
+        - Name: DHE-DSS-SEED-SHA
+          Value: "false"
+        - Name: DHE-RSA-SEED-SHA
+          Value: "false"
+        - Name: EDH-DSS-DES-CBC-SHA
+          Value: "false"
+        - Name: EDH-RSA-DES-CBC-SHA
+          Value: "false"
+        - Name: IDEA-CBC-SHA
+          Value: "false"
+        - Name: RC4-MD5
+          Value: "false"
+        - Name: SEED-SHA
+          Value: "false"
+        - Name: DES-CBC3-MD5
+          Value: "false"
+        - Name: DES-CBC-MD5
+          Value: "false"
+        - Name: RC2-CBC-MD5
+          Value: "false"
+        - Name: PSK-AES256-CBC-SHA
+          Value: "false"
+        - Name: PSK-3DES-EDE-CBC-SHA
+          Value: "false"
+        - Name: KRB5-DES-CBC3-SHA
+          Value: "false"
+        - Name: KRB5-DES-CBC3-MD5
+          Value: "false"
+        - Name: PSK-AES128-CBC-SHA
+          Value: "false"
+        - Name: PSK-RC4-SHA
+          Value: "false"
+        - Name: KRB5-RC4-SHA
+          Value: "false"
+        - Name: KRB5-RC4-MD5
+          Value: "false"
+        - Name: KRB5-DES-CBC-SHA
+          Value: "false"
+        - Name: KRB5-DES-CBC-MD5
+          Value: "false"
+        - Name: EXP-EDH-RSA-DES-CBC-SHA
+          Value: "false"
+        - Name: EXP-EDH-DSS-DES-CBC-SHA
+          Value: "false"
+        - Name: EXP-ADH-DES-CBC-SHA
+          Value: "false"
+        - Name: EXP-DES-CBC-SHA
+          Value: "false"
+        - Name: EXP-RC2-CBC-MD5
+          Value: "false"
+        - Name: EXP-KRB5-RC2-CBC-SHA
+          Value: "false"
+        - Name: EXP-KRB5-DES-CBC-SHA
+          Value: "false"
+        - Name: EXP-KRB5-RC2-CBC-MD5
+          Value: "false"
+        - Name: EXP-KRB5-DES-CBC-MD5
+          Value: "false"
+        - Name: EXP-ADH-RC4-MD5
+          Value: "false"
+        - Name: EXP-RC4-MD5
+          Value: "false"
+        - Name: EXP-KRB5-RC4-SHA
+          Value: "false"
+        - Name: EXP-KRB5-RC4-MD5
+          Value: "false"
       Listeners:
       - InstancePort: '4502'
         LoadBalancerPort: '80'

--- a/templates/cloudformation/apps/aem/full-set/publish-dispatcher.yaml
+++ b/templates/cloudformation/apps/aem/full-set/publish-dispatcher.yaml
@@ -407,6 +407,196 @@ Resources:
           Ref: PublishDispatcherLoadBalancerHealthCheckTargetParameter
         Timeout: '5'
         UnhealthyThreshold: '10'
+      Policies:
+      - PolicyName: AOCELBSecurityPolicy-TLS-1-2-2017-01
+        PolicyType: SSLNegotiationPolicyType
+        Attributes:
+        - Name: Protocol-SSLv3
+          Value: "false"
+        - Name: Protocol-TLSv1
+          Value: "false"
+        - Name: Protocol-TLSv1.1
+          Value: "false"
+        - Name: Protocol-TLSv1.2
+          Value: "true"
+        - Name: Server-Defined-Cipher-Order
+          Value: "true"
+        - Name: ECDHE-ECDSA-AES128-GCM-SHA256
+          Value: "true"
+        - Name: ECDHE-RSA-AES128-GCM-SHA256
+          Value: "true"
+        - Name: ECDHE-ECDSA-AES128-SHA256
+          Value: "true"
+        - Name: ECDHE-RSA-AES128-SHA256
+          Value: "true"
+        - Name: ECDHE-ECDSA-AES128-SHA
+          Value: "false"
+        - Name: ECDHE-RSA-AES128-SHA
+          Value: "false"
+        - Name: DHE-RSA-AES128-SHA
+          Value: "false"
+        - Name: ECDHE-ECDSA-AES256-GCM-SHA384
+          Value: "true"
+        - Name: ECDHE-RSA-AES256-GCM-SHA384
+          Value: "true"
+        - Name: ECDHE-ECDSA-AES256-SHA384
+          Value: "true"
+        - Name: ECDHE-RSA-AES256-SHA384
+          Value: "true"
+        - Name: ECDHE-RSA-AES256-SHA
+          Value: "false"
+        - Name: ECDHE-ECDSA-AES256-SHA
+          Value: "false"
+        - Name: AES128-GCM-SHA256
+          Value: "true"
+        - Name: AES128-SHA256
+          Value: "true"
+        - Name: AES128-SHA
+          Value: "false"
+        - Name: AES256-GCM-SHA384
+          Value: "true"
+        - Name: AES256-SHA256
+          Value: "true"
+        - Name: AES256-SHA
+          Value: "false"
+        - Name: DHE-DSS-AES128-SHA
+          Value: "false"
+        - Name: CAMELLIA128-SHA
+          Value: "false"
+        - Name: EDH-RSA-DES-CBC3-SHA
+          Value: "false"
+        - Name: DES-CBC3-SHA
+          Value: "false"
+        - Name: ECDHE-RSA-RC4-SHA
+          Value: "false"
+        - Name: RC4-SHA
+          Value: "false"
+        - Name: ECDHE-ECDSA-RC4-SHA
+          Value: "false"
+        - Name: DHE-DSS-AES256-GCM-SHA384
+          Value: "false"
+        - Name: DHE-RSA-AES256-GCM-SHA384
+          Value: "false"
+        - Name: DHE-RSA-AES256-SHA256
+          Value: "false"
+        - Name: DHE-DSS-AES256-SHA256
+          Value: "false"
+        - Name: DHE-RSA-AES256-SHA
+          Value: "false"
+        - Name: DHE-DSS-AES256-SHA
+          Value: "false"
+        - Name: DHE-RSA-CAMELLIA256-SHA
+          Value: "false"
+        - Name: DHE-DSS-CAMELLIA256-SHA
+          Value: "false"
+        - Name: CAMELLIA256-SHA
+          Value: "false"
+        - Name: EDH-DSS-DES-CBC3-SHA
+          Value: "false"
+        - Name: DHE-DSS-AES128-GCM-SHA256
+          Value: "false"
+        - Name: DHE-RSA-AES128-GCM-SHA256
+          Value: "false"
+        - Name: DHE-RSA-AES128-SHA256
+          Value: "false"
+        - Name: DHE-DSS-AES128-SHA256
+          Value: "false"
+        - Name: DHE-RSA-CAMELLIA128-SHA
+          Value: "false"
+        - Name: DHE-DSS-CAMELLIA128-SHA
+          Value: "false"
+        - Name: ADH-AES128-GCM-SHA256
+          Value: "false"
+        - Name: ADH-AES128-SHA
+          Value: "false"
+        - Name: ADH-AES128-SHA256
+          Value: "false"
+        - Name: ADH-AES256-GCM-SHA384
+          Value: "false"
+        - Name: ADH-AES256-SHA
+          Value: "false"
+        - Name: ADH-AES256-SHA256
+          Value: "false"
+        - Name: ADH-CAMELLIA128-SHA
+          Value: "false"
+        - Name: ADH-CAMELLIA256-SHA
+          Value: "false"
+        - Name: ADH-DES-CBC3-SHA
+          Value: "false"
+        - Name: ADH-DES-CBC-SHA
+          Value: "false"
+        - Name: ADH-RC4-MD5
+          Value: "false"
+        - Name: ADH-SEED-SHA
+          Value: "false"
+        - Name: DES-CBC-SHA
+          Value: "false"
+        - Name: DHE-DSS-SEED-SHA
+          Value: "false"
+        - Name: DHE-RSA-SEED-SHA
+          Value: "false"
+        - Name: EDH-DSS-DES-CBC-SHA
+          Value: "false"
+        - Name: EDH-RSA-DES-CBC-SHA
+          Value: "false"
+        - Name: IDEA-CBC-SHA
+          Value: "false"
+        - Name: RC4-MD5
+          Value: "false"
+        - Name: SEED-SHA
+          Value: "false"
+        - Name: DES-CBC3-MD5
+          Value: "false"
+        - Name: DES-CBC-MD5
+          Value: "false"
+        - Name: RC2-CBC-MD5
+          Value: "false"
+        - Name: PSK-AES256-CBC-SHA
+          Value: "false"
+        - Name: PSK-3DES-EDE-CBC-SHA
+          Value: "false"
+        - Name: KRB5-DES-CBC3-SHA
+          Value: "false"
+        - Name: KRB5-DES-CBC3-MD5
+          Value: "false"
+        - Name: PSK-AES128-CBC-SHA
+          Value: "false"
+        - Name: PSK-RC4-SHA
+          Value: "false"
+        - Name: KRB5-RC4-SHA
+          Value: "false"
+        - Name: KRB5-RC4-MD5
+          Value: "false"
+        - Name: KRB5-DES-CBC-SHA
+          Value: "false"
+        - Name: KRB5-DES-CBC-MD5
+          Value: "false"
+        - Name: EXP-EDH-RSA-DES-CBC-SHA
+          Value: "false"
+        - Name: EXP-EDH-DSS-DES-CBC-SHA
+          Value: "false"
+        - Name: EXP-ADH-DES-CBC-SHA
+          Value: "false"
+        - Name: EXP-DES-CBC-SHA
+          Value: "false"
+        - Name: EXP-RC2-CBC-MD5
+          Value: "false"
+        - Name: EXP-KRB5-RC2-CBC-SHA
+          Value: "false"
+        - Name: EXP-KRB5-DES-CBC-SHA
+          Value: "false"
+        - Name: EXP-KRB5-RC2-CBC-MD5
+          Value: "false"
+        - Name: EXP-KRB5-DES-CBC-MD5
+          Value: "false"
+        - Name: EXP-ADH-RC4-MD5
+          Value: "false"
+        - Name: EXP-RC4-MD5
+          Value: "false"
+        - Name: EXP-KRB5-RC4-SHA
+          Value: "false"
+        - Name: EXP-KRB5-RC4-MD5
+          Value: "false"
       Listeners:
       - InstancePort: '80'
         LoadBalancerPort: '80'


### PR DESCRIPTION
### Changed
- Changed default parameter `compute.elb_cipher_suite` to 
`AOCELBSecurityPolicy-TLS-1-2-2017-01`
- Disable TLS 1.0 & TLS 1.1 support for Author-Dispatcher, 
Publish-Dispatcher & Author ELB