### PR TITLE
Corrects replication agent parameter structure in hieradata

### DIFF
--- a/templates/ansible/stack-provisioner-hieradata.j2
+++ b/templates/ansible/stack-provisioner-hieradata.j2
@@ -262,6 +262,6 @@ orchestrator::enable_cloudwatch_s3_stream: {{ aws.cloudwatch.enable_log_subscrip
 action_scheduled_jobs::cloudwatch_log_subscription_arn: {{ aws.cloudwatch.log_subscription_arn }}
 
 # Configuration of Publish replication-agent for Consolidated env.
-aem_aws_stack_provisioner::author_publish_dispatcher::publish_replication_agent_protocol: {{ author_publish_dispatcher.replication_agent.publish_protocol }}
-aem_aws_stack_provisioner::author_publish_dispatcher::publish_replication_agent_port: {{ author_publish_dispatcher.replication_agent.publish_port }}
+author_publish_dispatcher::publish_replication_agent_protocol: {{ author_publish_dispatcher.replication_agent.publish_protocol }}
+author_publish_dispatcher::publish_replication_agent_port: {{ author_publish_dispatcher.replication_agent.publish_port }}
 


### PR DESCRIPTION
Resolves RS-71 where replication agent protocol and port were not being passed to stack provisioner from config.