### PR TITLE
Update lambdas runtime version to python3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changes
+- Update lambda functions' version from python3.7 to python3.8 [#472]
 
 ## 5.19.0 - 2022-11-22
 

--- a/templates/cloudformation/apps/aem-stack-manager/stack-manager-c.yaml
+++ b/templates/cloudformation/apps/aem-stack-manager/stack-manager-c.yaml
@@ -264,7 +264,7 @@ Resources:
       Role:
         Fn::ImportValue:
           Fn::Sub: ${MainStackPrefixParameter}-StackManagerLambdaServiceRoleArn
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout: 60
     Type: AWS::Lambda::Function
   ManagerTopicPermission:
@@ -319,7 +319,7 @@ Resources:
       Role:
         Fn::ImportValue:
           Fn::Sub: ${MainStackPrefixParameter}-StackManagerLambdaServiceRoleArn
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout: 60
     Type: AWS::Lambda::Function
   OfflineBackupTopic:
@@ -380,7 +380,7 @@ Resources:
       Role:
         Fn::ImportValue:
           Fn::Sub: ${MainStackPrefixParameter}-StackManagerLambdaServiceRoleArn
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout: 60
     Type: AWS::Lambda::Function
   QueryLambdaProdAlias:

--- a/templates/cloudformation/apps/aem-stack-manager/stack-manager.yaml
+++ b/templates/cloudformation/apps/aem-stack-manager/stack-manager.yaml
@@ -264,7 +264,7 @@ Resources:
       Role:
         Fn::ImportValue:
           Fn::Sub: ${MainStackPrefixParameter}-StackManagerLambdaServiceRoleArn
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout: 60
     Type: AWS::Lambda::Function
   ManagerTopicPermission:
@@ -319,7 +319,7 @@ Resources:
       Role:
         Fn::ImportValue:
           Fn::Sub: ${MainStackPrefixParameter}-StackManagerLambdaServiceRoleArn
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout: 60
     Type: AWS::Lambda::Function
   OfflineBackupTopic:
@@ -380,7 +380,7 @@ Resources:
       Role:
         Fn::ImportValue:
           Fn::Sub: ${MainStackPrefixParameter}-StackManagerLambdaServiceRoleArn
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout: 60
     Type: AWS::Lambda::Function
   QueryLambdaProdAlias:

--- a/templates/cloudformation/apps/aem-stack-manager/utilities.yaml
+++ b/templates/cloudformation/apps/aem-stack-manager/utilities.yaml
@@ -134,7 +134,7 @@ Resources:
       Role:
         Fn::ImportValue:
           Fn::Sub: ${MainStackPrefixParameter}-StackManagerLambdaServiceRoleArn
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout: 300
     Type: AWS::Lambda::Function
   CloudWatchS3StreamLambdaPermission:
@@ -283,6 +283,6 @@ Resources:
       Role:
         Fn::ImportValue:
           Fn::Sub: ${MainStackPrefixParameter}-StackManagerLambdaServiceRoleArn
-      Runtime: python3.7
+      Runtime: python3.8
       Timeout: 900
     Type: AWS::Lambda::Function


### PR DESCRIPTION
Python runtime v3.7 is set to deprecate in Nov'2023. Thus, this PR upgrades the Python3.7 lambdas to Python3.8 runtime.
For more info on to-be-deprecated runtimes https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html